### PR TITLE
Add yield curve monitoring tool with Netlify data service

### DIFF
--- a/netlify/functions/yield-curves.js
+++ b/netlify/functions/yield-curves.js
@@ -1,0 +1,249 @@
+const TREASURY_URL = "https://home.treasury.gov/resource-center/data-chart-center/interest-rates/daily-treasury-par-yield-curve-rates.csv";
+const FRED_BASE = "https://fred.stlouisfed.org/graph/fredgraph.csv";
+
+const MATURITY_MAP = [
+  { column: "1 Mo", key: "1m", label: "1 Month" },
+  { column: "2 Mo", key: "2m", label: "2 Month" },
+  { column: "3 Mo", key: "3m", label: "3 Month" },
+  { column: "6 Mo", key: "6m", label: "6 Month" },
+  { column: "1 Yr", key: "1y", label: "1 Year" },
+  { column: "2 Yr", key: "2y", label: "2 Year" },
+  { column: "3 Yr", key: "3y", label: "3 Year" },
+  { column: "5 Yr", key: "5y", label: "5 Year" },
+  { column: "7 Yr", key: "7y", label: "7 Year" },
+  { column: "10 Yr", key: "10y", label: "10 Year" },
+  { column: "20 Yr", key: "20y", label: "20 Year" },
+  { column: "30 Yr", key: "30y", label: "30 Year" }
+];
+
+const FRED_SERIES = [
+  {
+    id: "BAMLC0A0CM",
+    label: "ICE BofA US Corporate Index OAS",
+    category: "investmentGradeOas"
+  },
+  {
+    id: "BAMLH0A0HYM2",
+    label: "ICE BofA US High Yield Index OAS",
+    category: "highYieldOas"
+  },
+  {
+    id: "T10Y2Y",
+    label: "10Y minus 2Y Treasury Spread",
+    category: "tenTwoSpread"
+  }
+];
+
+const DEFAULT_RANGE_DAYS = 540;
+
+function parseNumber(value) {
+  if (value === undefined || value === null) return null;
+  const cleaned = String(value).trim();
+  if (!cleaned || cleaned === "N/A") return null;
+  const number = Number.parseFloat(cleaned.replace(/,/g, ""));
+  return Number.isFinite(number) ? number : null;
+}
+
+function toBasisPoints(value) {
+  if (value === null || value === undefined) return null;
+  return Number((value * 100).toFixed(1));
+}
+
+function parseCsv(text) {
+  const lines = text.trim().split(/\r?\n/).filter(Boolean);
+  if (!lines.length) return { header: [], rows: [] };
+
+  const header = lines[0].split(",").map((part) => part.trim());
+  const rows = lines.slice(1).map((line) => line.split(","));
+
+  return { header, rows };
+}
+
+function parseTreasuryData(csvText, rangeDays) {
+  const { header, rows } = parseCsv(csvText);
+  if (!header.length) {
+    throw new Error("Treasury response was empty");
+  }
+
+  const dateIndex = header.findIndex((column) => /date/i.test(column));
+  if (dateIndex === -1) {
+    throw new Error("Treasury response missing Date column");
+  }
+
+  const cutoff = new Date();
+  cutoff.setUTCDate(cutoff.getUTCDate() - rangeDays);
+
+  const maturities = MATURITY_MAP.filter((entry) => header.includes(entry.column));
+  const columnIndices = new Map();
+  maturities.forEach((entry) => {
+    columnIndices.set(entry.key, header.indexOf(entry.column));
+  });
+  const series = [];
+
+  rows.forEach((columns) => {
+    const rawDate = columns[dateIndex];
+    const date = rawDate ? new Date(rawDate) : null;
+    if (!date || Number.isNaN(date.getTime())) {
+      return;
+    }
+
+    if (date < cutoff) {
+      return;
+    }
+
+    const yields = {};
+    maturities.forEach(({ key }) => {
+      const columnIndex = columnIndices.get(key);
+      const value = columnIndex === -1 ? null : parseNumber(columns[columnIndex]);
+      yields[key] = value;
+    });
+
+    series.push({
+      date: date.toISOString().slice(0, 10),
+      values: yields
+    });
+  });
+
+  series.sort((a, b) => a.date.localeCompare(b.date));
+
+  return {
+    maturities,
+    series
+  };
+}
+
+async function fetchFredSeries(seriesId, rangeDays) {
+  const startDate = new Date();
+  startDate.setUTCDate(startDate.getUTCDate() - rangeDays - 14);
+  const cosd = startDate.toISOString().slice(0, 10);
+
+  const url = `${FRED_BASE}?id=${encodeURIComponent(seriesId)}&cosd=${cosd}`;
+  const response = await fetch(url, {
+    headers: {
+      "Accept": "text/csv, text/plain"
+    }
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`FRED request failed (${seriesId}): ${response.status} ${text}`);
+  }
+
+  const csvText = await response.text();
+  const { rows } = parseCsv(csvText);
+
+  const cutoff = new Date();
+  cutoff.setUTCDate(cutoff.getUTCDate() - rangeDays);
+
+  const data = rows
+    .map(([date, value]) => {
+      const parsedDate = date ? new Date(date) : null;
+      if (!parsedDate || Number.isNaN(parsedDate.getTime())) return null;
+      if (parsedDate < cutoff) return null;
+      const parsedValue = parseNumber(value);
+      return {
+        date: parsedDate.toISOString().slice(0, 10),
+        value: parsedValue
+      };
+    })
+    .filter(Boolean)
+    .sort((a, b) => a.date.localeCompare(b.date));
+
+  return data;
+}
+
+async function buildResponse(rangeDays) {
+  const [treasuryRes, ...fredSeries] = await Promise.all([
+    fetch(TREASURY_URL),
+    ...FRED_SERIES.map((series) => fetchFredSeries(series.id, rangeDays))
+  ]);
+
+  if (!treasuryRes.ok) {
+    const text = await treasuryRes.text();
+    throw new Error(`Treasury request failed: ${treasuryRes.status} ${text}`);
+  }
+
+  const treasuryCsv = await treasuryRes.text();
+  const treasury = parseTreasuryData(treasuryCsv, rangeDays);
+
+  const fred = FRED_SERIES.map((seriesMeta, index) => {
+    const rawSeries = fredSeries[index];
+    const data = rawSeries.map((entry) => {
+      let value = entry.value;
+      if (seriesMeta.category !== "tenTwoSpread" && value !== null) {
+        value = toBasisPoints(value);
+      } else if (seriesMeta.category === "tenTwoSpread" && value !== null) {
+        value = Number((value * 100).toFixed(0));
+      }
+      return {
+        date: entry.date,
+        value
+      };
+    });
+
+    return {
+      id: seriesMeta.id,
+      label: seriesMeta.label,
+      category: seriesMeta.category,
+      data
+    };
+  });
+
+  return {
+    fetchedAt: new Date().toISOString(),
+    rangeDays,
+    treasury,
+    fred
+  };
+}
+
+exports.handler = async (event) => {
+  if (event.httpMethod === "OPTIONS") {
+    return {
+      statusCode: 204,
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Headers": "Content-Type",
+        "Access-Control-Allow-Methods": "GET,OPTIONS"
+      },
+      body: ""
+    };
+  }
+
+  if (event.httpMethod !== "GET") {
+    return {
+      statusCode: 405,
+      headers: {
+        Allow: "GET, OPTIONS",
+        "Access-Control-Allow-Origin": "*"
+      },
+      body: JSON.stringify({ error: "Method not allowed" })
+    };
+  }
+
+  const rangeParam = Number.parseInt(event?.queryStringParameters?.range, 10);
+  const rangeDays = Number.isFinite(rangeParam) && rangeParam > 0 ? Math.min(rangeParam, 1095) : DEFAULT_RANGE_DAYS;
+
+  try {
+    const payload = await buildResponse(rangeDays);
+    return {
+      statusCode: 200,
+      headers: {
+        "Content-Type": "application/json",
+        "Cache-Control": "no-store",
+        "Access-Control-Allow-Origin": "*"
+      },
+      body: JSON.stringify(payload)
+    };
+  } catch (error) {
+    console.error("yield-curves function error", error);
+    return {
+      statusCode: 502,
+      headers: {
+        "Content-Type": "application/json",
+        "Access-Control-Allow-Origin": "*"
+      },
+      body: JSON.stringify({ error: error.message || "Failed to fetch yield data" })
+    };
+  }
+};

--- a/tools/yield-curves/app.html
+++ b/tools/yield-curves/app.html
@@ -1,6 +1,6 @@
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/luxon@3.4.4/build/global/luxon.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-luxon@1.3.1/dist/chartjs-adapter-luxon.umd.min.js"></script>
@@ -62,18 +62,6 @@
     display: inline-flex;
     align-items: center;
     gap: 6px;
-  }
-
-  .yc-meta .badge {
-    display: inline-flex;
-    align-items: center;
-    padding: 4px 9px;
-    background: #eef2ff;
-    color: #4338ca;
-    border-radius: 999px;
-    font-size: 0.85rem;
-    font-weight: 600;
-    letter-spacing: 0.02em;
   }
 
   .yc-status {
@@ -181,6 +169,22 @@
 
   .yc-panel canvas {
     width: 100% !important;
+    height: clamp(240px, 38vh, 360px) !important;
+  }
+
+  .yc-panel-table {
+    background: linear-gradient(180deg, rgba(15, 23, 42, 0.92) 0%, rgba(15, 23, 42, 0.97) 100%);
+    border: 1px solid rgba(148, 163, 184, 0.28);
+    box-shadow: none;
+    color: #e2e8f0;
+  }
+
+  .yc-panel-table h2 {
+    color: #f8fafc;
+  }
+
+  .yc-panel-table p {
+    color: #cbd5f5;
   }
 
   .yc-panel .panel-meta {
@@ -208,6 +212,18 @@
     border-collapse: collapse;
   }
 
+  .yc-panel-table .yc-yield-table {
+    background: rgba(30, 41, 59, 0.55);
+    border-radius: 16px;
+    padding: 12px 16px;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+  }
+
+  .yc-panel-table table {
+    min-width: 520px;
+    font-variant-numeric: tabular-nums;
+  }
+
   .yc-panel thead th {
     text-align: left;
     font-size: 0.8rem;
@@ -217,11 +233,35 @@
     padding-bottom: 10px;
   }
 
+  .yc-panel-table thead th {
+    color: rgba(226, 232, 240, 0.75);
+    padding: 0 12px 12px;
+  }
+
   .yc-panel tbody td {
     padding: 9px 0;
     border-top: 1px solid rgba(148, 163, 184, 0.18);
     font-size: 0.95rem;
     color: #1f2933;
+  }
+
+  .yc-panel-table tbody td {
+    padding: 10px 12px;
+    color: #f1f5f9;
+    border-top: 1px solid rgba(148, 163, 184, 0.28);
+  }
+
+  .yc-panel-table tbody tr:nth-child(even) td {
+    background: rgba(15, 23, 42, 0.55);
+  }
+
+  .yc-panel-table tbody tr:first-of-type td {
+    padding-top: 10px;
+    border-top: none;
+  }
+
+  .yc-panel-table tbody tr:last-of-type td {
+    padding-bottom: 10px;
   }
 
   .yc-panel tbody tr:first-of-type td {
@@ -234,12 +274,9 @@
   }
 
   .yc-yield-table {
+    background: rgba(30, 41, 59, 0.9);
     margin-top: 12px;
     overflow-x: auto;
-  }
-
-  .yc-yield-table table {
-    min-width: 520px;
   }
 
   .yc-empty {
@@ -273,11 +310,6 @@
 
     .yc-meta {
       color: #a5b4fc;
-    }
-
-    .yc-meta .badge {
-      background: rgba(99, 102, 241, 0.18);
-      color: #c7d2fe;
     }
 
     .yc-summary-card {
@@ -317,10 +349,9 @@
       border-color: rgba(148, 163, 184, 0.22);
     }
 
-    .yc-yield-table {
-      background: rgba(15, 23, 42, 0.35);
-      border-radius: 14px;
-      padding: 8px 14px;
+    .yc-panel-table {
+      background: linear-gradient(180deg, rgba(10, 17, 33, 0.95) 0%, rgba(8, 13, 27, 0.98) 100%);
+      border-color: rgba(99, 102, 241, 0.35);
     }
 
     .yc-empty {
@@ -330,54 +361,7 @@
   }
 </style>
 
-<div class="yield-curves-app" id="yield-curves-app">
-  <header>
-    <div class="badge">Fixed-Income Intelligence</div>
-    <h1>Yield Curve & Credit Spread Monitor</h1>
-    <p class="subhead">
-      Live US Treasury par yields alongside key corporate bond spreads to support asset-liability management and tactical asset allocation.
-      Trends are refreshed directly from the US Treasury and Federal Reserve (FRED).
-    </p>
-    <div class="yc-meta" data-role="meta">
-      <span><strong>Last refreshed:</strong> <time data-field="refreshed">—</time></span>
-      <span><strong>Data window:</strong> <span data-field="range">—</span></span>
-      <span class="badge">Netlify Functions</span>
-    </div>
-    <div class="yc-status" data-role="status">Loading market data…</div>
-  </header>
-
-  <section class="yc-summary-grid" data-section="summary">
-    <!-- Summary cards injected by script -->
-  </section>
-
-  <section class="yc-layout">
-    <article class="yc-panel">
-      <div>
-        <h2>Yield Curve Profiles</h2>
-        <p>Compare the latest Treasury curve with levels a month and a year ago to understand shifts in term premium and slope.</p>
-      </div>
-      <canvas id="yield-curve-chart" height="320"></canvas>
-      <div class="panel-meta" data-role="curve-meta"></div>
-    </article>
-
-    <article class="yc-panel">
-      <div>
-        <h2>Credit & Curve Spreads</h2>
-        <p>Track benchmark corporate bond spreads and the 10Y–2Y curve to gauge recession risk and relative value.</p>
-      </div>
-      <canvas id="spread-chart" height="320"></canvas>
-      <div class="panel-meta" data-role="spread-meta"></div>
-    </article>
-  </section>
-
-  <section class="yc-panel" style="margin-top: 28px;">
-    <div>
-      <h2>Recent Daily Treasury Par Yields</h2>
-      <p>An extract of the latest observations for quick reference across the curve.</p>
-    </div>
-    <div class="yc-yield-table" data-role="yield-table"></div>
-  </section>
-</div>
+<div class="yield-curves-app" id="yield-curves-app"></div>
 
 <script>
   (function () {
@@ -385,6 +369,70 @@
       data: null,
       charts: {}
     };
+
+    const dom = {
+      app: null,
+      summarySection: null,
+      statusBanner: null,
+      metaFields: {
+        refreshed: null,
+        range: null
+      },
+      curveMeta: null,
+      spreadMeta: null,
+      tableContainer: null
+    };
+    let initialized = false;
+
+    function renderShell(app) {
+      app.innerHTML = `
+<header class="yc-header">
+  <div class="badge">Fixed-Income Intelligence</div>
+  <h1>Yield Curve &amp; Credit Spread Monitor</h1>
+  <p class="subhead">
+    Live US Treasury par yields alongside key corporate bond spreads to support asset-liability management and tactical asset allocation.
+    Trends are refreshed directly from the US Treasury and Federal Reserve (FRED).
+  </p>
+  <div class="yc-meta" data-role="meta">
+    <span><strong>Last refreshed:</strong> <span data-field="refreshed">—</span></span>
+    <span><strong>Data window:</strong> <span data-field="range">—</span></span>
+  </div>
+  <div class="yc-status" data-role="status">Loading market data…</div>
+</header>
+
+<section class="yc-summary-grid" data-section="summary">
+  <!-- Summary cards injected by script -->
+</section>
+
+<section class="yc-layout">
+  <article class="yc-panel">
+    <div>
+      <h2>Yield Curve Profiles</h2>
+      <p>Compare the latest Treasury curve with levels a month and a year ago to understand shifts in term premium and slope.</p>
+    </div>
+    <canvas id="yield-curve-chart" height="320"></canvas>
+    <div class="panel-meta" data-role="curve-meta"></div>
+  </article>
+
+  <article class="yc-panel">
+    <div>
+      <h2>Credit &amp; Curve Spreads</h2>
+      <p>Track benchmark corporate bond spreads and the 10Y–2Y curve to gauge recession risk and relative value.</p>
+    </div>
+    <canvas id="spread-chart" height="320"></canvas>
+    <div class="panel-meta" data-role="spread-meta"></div>
+  </article>
+</section>
+
+<section class="yc-panel yc-panel-table" style="margin-top: 28px;">
+  <div>
+    <h2>Recent Daily Treasury Par Yields</h2>
+    <p>An extract of the latest observations for quick reference across the curve.</p>
+  </div>
+  <div class="yc-yield-table" data-role="yield-table"></div>
+</section>
+      `;
+    }
 
     function hexToRgba(hex, alpha) {
       if (!hex) return `rgba(99, 102, 241, ${alpha})`;
@@ -398,26 +446,44 @@
       return `rgba(${r}, ${g}, ${b}, ${alpha})`;
     }
 
-    const app = document.getElementById("yield-curves-app");
-    const summarySection = app.querySelector('[data-section="summary"]');
-    const statusBanner = app.querySelector('[data-role="status"]');
-    const metaFields = {
-      refreshed: app.querySelector('[data-field="refreshed"]'),
-      range: app.querySelector('[data-field="range"]')
-    };
-    const curveMeta = app.querySelector('[data-role="curve-meta"]');
-    const spreadMeta = app.querySelector('[data-role="spread-meta"]');
-    const tableContainer = app.querySelector('[data-role="yield-table"]');
-
-    function setStatus(message, type = "info") {
-      if (!statusBanner) return;
-      if (!message) {
-        statusBanner.style.display = "none";
+    function init() {
+      if (initialized) {
         return;
       }
-      statusBanner.textContent = message;
-      statusBanner.classList.toggle("error", type === "error");
-      statusBanner.style.display = "block";
+
+      const app = document.getElementById("yield-curves-app");
+      if (!app) {
+        console.warn("Yield curves root element not found");
+        return;
+      }
+
+      renderShell(app);
+
+      dom.app = app;
+      dom.summarySection = app.querySelector('[data-section="summary"]');
+      dom.statusBanner = app.querySelector('[data-role="status"]');
+      dom.metaFields = {
+        refreshed: app.querySelector('[data-field="refreshed"]'),
+        range: app.querySelector('[data-field="range"]')
+      };
+      dom.curveMeta = app.querySelector('[data-role="curve-meta"]');
+      dom.spreadMeta = app.querySelector('[data-role="spread-meta"]');
+      dom.tableContainer = app.querySelector('[data-role="yield-table"]');
+
+      initialized = true;
+      loadData();
+    }
+
+    function setStatus(message, type = "info") {
+      const banner = dom.statusBanner;
+      if (!banner) return;
+      if (!message) {
+        banner.style.display = "none";
+        return;
+      }
+      banner.textContent = message;
+      banner.classList.toggle("error", type === "error");
+      banner.style.display = "block";
     }
 
     function formatPercent(value, decimals = 2) {
@@ -468,6 +534,7 @@
     }
 
     function buildSummaryCards(data) {
+      const summarySection = dom.summarySection;
       if (!summarySection) return;
       summarySection.innerHTML = "";
       const latest = data.treasury.series[data.treasury.series.length - 1];
@@ -555,6 +622,16 @@
       const monthAgo = findHistoricalPoint(data.treasury.series, 30);
       const yearAgo = findHistoricalPoint(data.treasury.series, 365);
 
+      const yieldValues = [latest, monthAgo, yearAgo]
+        .filter(Boolean)
+        .flatMap((point) => data.treasury.maturities.map(({ key }) => point?.values?.[key]))
+        .filter((value) => typeof value === "number" && Number.isFinite(value));
+      const maxYield = yieldValues.length ? Math.max(...yieldValues) : 5;
+      const bounds = {
+        min: 0,
+        max: Math.max(5, Math.ceil((maxYield + 0.25) * 2) / 2)
+      };
+
       const datasetForPoint = (point, label, color) => ({
         label,
         data: data.treasury.maturities.map(({ key }) => point?.values?.[key] ?? null),
@@ -579,6 +656,8 @@
 
       if (state.charts.curve) {
         state.charts.curve.data = chartData;
+        state.charts.curve.options.scales.y.min = bounds.min;
+        state.charts.curve.options.scales.y.max = bounds.max;
         state.charts.curve.update();
       } else {
         state.charts.curve = new Chart(ctx, {
@@ -586,13 +665,14 @@
           data: chartData,
           options: {
             responsive: true,
-            maintainAspectRatio: false,
             scales: {
               y: {
                 title: {
                   display: true,
                   text: "Yield (%)"
                 },
+                min: bounds.min,
+                max: bounds.max,
                 ticks: {
                   callback: (value) => `${value}%`
                 },
@@ -620,8 +700,9 @@
         });
       }
 
-      if (curveMeta) {
-        curveMeta.innerHTML = `Curves plotted for <strong>${maturities.length}</strong> standard maturities. Data source: US Treasury.`;
+      const meta = dom.curveMeta;
+      if (meta) {
+        meta.innerHTML = `Curves plotted for <strong>${maturities.length}</strong> standard maturities. Data source: US Treasury.`;
       }
     }
 
@@ -646,6 +727,16 @@
         pointHoverRadius: 3
       }));
 
+      const spreadValues = data.fred
+        .flatMap((series) => series.data.map((point) => point.value))
+        .filter((value) => typeof value === "number" && Number.isFinite(value));
+      const maxSpread = spreadValues.length ? Math.max(...spreadValues) : 400;
+      const minSpread = spreadValues.length ? Math.min(...spreadValues) : -200;
+      const spreadBounds = {
+        min: Math.min(-50, Math.floor((minSpread - 25) / 25) * 25),
+        max: Math.ceil((maxSpread + 25) / 25) * 25
+      };
+
       const yLabel = (value, series) => {
         if (series.category === "tenTwoSpread") {
           return formatBps(value, 0);
@@ -655,6 +746,8 @@
 
       if (state.charts.spread) {
         state.charts.spread.data.datasets = datasets;
+        state.charts.spread.options.scales.y.min = spreadBounds.min;
+        state.charts.spread.options.scales.y.max = spreadBounds.max;
         state.charts.spread.update();
       } else {
         state.charts.spread = new Chart(ctx, {
@@ -664,7 +757,6 @@
           },
           options: {
             responsive: true,
-            maintainAspectRatio: false,
             scales: {
               x: {
                 type: "time",
@@ -689,6 +781,8 @@
                   display: true,
                   text: "Basis Points"
                 },
+                min: spreadBounds.min,
+                max: spreadBounds.max,
                 ticks: {
                   callback: (value) => `${value}`
                 },
@@ -714,16 +808,18 @@
         });
       }
 
-      if (spreadMeta) {
-        spreadMeta.innerHTML = `Spreads expressed in basis points. Source: FRED (ICE BofA) & Treasury.`;
+      const meta = dom.spreadMeta;
+      if (meta) {
+        meta.innerHTML = `Spreads expressed in basis points. Source: FRED (ICE BofA) &amp; Treasury.`;
       }
     }
 
     function buildTable(data) {
-      if (!tableContainer) return;
+      const container = dom.tableContainer;
+      if (!container) return;
       const recent = [...data.treasury.series].slice(-7).reverse();
       if (!recent.length) {
-        tableContainer.innerHTML = '<div class="yc-empty">No recent observations available.</div>';
+        container.innerHTML = '<div class="yc-empty">No recent observations available.</div>';
         return;
       }
 
@@ -757,19 +853,20 @@
       });
 
       table.appendChild(tbody);
-      tableContainer.innerHTML = "";
-      tableContainer.appendChild(table);
+      container.innerHTML = "";
+      container.appendChild(table);
     }
 
     function applyMeta(data) {
-      if (metaFields.refreshed) {
-        metaFields.refreshed.textContent = new Date(data.fetchedAt).toLocaleString(undefined, {
+      const meta = dom.metaFields;
+      if (meta.refreshed) {
+        meta.refreshed.textContent = new Date(data.fetchedAt).toLocaleString(undefined, {
           dateStyle: "medium",
           timeStyle: "short"
         });
       }
-      if (metaFields.range) {
-        metaFields.range.textContent = `${data.rangeDays} calendar days`;
+      if (meta.range) {
+        meta.range.textContent = `${data.rangeDays} calendar days`;
       }
     }
 
@@ -791,10 +888,16 @@
       } catch (error) {
         console.error(error);
         setStatus("Unable to load live data. Please refresh or try again later.", "error");
-        tableContainer.innerHTML = '<div class="yc-empty">Live data unavailable. Check your connection or Netlify function logs.</div>';
+        if (dom.tableContainer) {
+          dom.tableContainer.innerHTML = '<div class="yc-empty">Live data unavailable. Check your connection or Netlify function logs.</div>';
+        }
       }
     }
 
-    loadData();
+    if (document.readyState === "loading") {
+      document.addEventListener("DOMContentLoaded", init, { once: true });
+    } else {
+      init();
+    }
   })();
 </script>

--- a/tools/yield-curves/app.html
+++ b/tools/yield-curves/app.html
@@ -1,0 +1,800 @@
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.7/dist/chart.umd.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/luxon@3.4.4/build/global/luxon.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-luxon@1.3.1/dist/chartjs-adapter-luxon.umd.min.js"></script>
+<style>
+  :root {
+    color-scheme: light dark;
+  }
+
+  .yield-curves-app {
+    font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    background: linear-gradient(180deg, rgba(246, 248, 252, 0.92) 0%, rgba(239, 241, 247, 0.92) 100%);
+    color: #111827;
+    padding: clamp(20px, 6vw, 48px);
+    border-radius: 22px;
+    box-shadow: 0 24px 60px rgba(15, 23, 42, 0.08);
+    position: relative;
+    overflow: hidden;
+  }
+
+  .yield-curves-app::before {
+    content: "";
+    position: absolute;
+    inset: -140px -180px auto auto;
+    width: 320px;
+    height: 320px;
+    background: radial-gradient(circle at top right, rgba(79, 70, 229, 0.12), transparent 65%);
+    pointer-events: none;
+  }
+
+  .yield-curves-app * {
+    box-sizing: border-box;
+  }
+
+  .yield-curves-app h1 {
+    font-size: clamp(1.75rem, 3vw, 2.25rem);
+    font-weight: 700;
+    margin: 0;
+    color: #0b1736;
+  }
+
+  .yield-curves-app .subhead {
+    margin-top: 12px;
+    color: #4b5563;
+    font-size: 1rem;
+    max-width: 720px;
+    line-height: 1.55;
+  }
+
+  .yc-meta {
+    margin-top: 14px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px 18px;
+    font-size: 0.95rem;
+    color: #52606d;
+  }
+
+  .yc-meta span {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .yc-meta .badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 4px 9px;
+    background: #eef2ff;
+    color: #4338ca;
+    border-radius: 999px;
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+  }
+
+  .yc-status {
+    margin-top: 18px;
+    padding: 14px 16px;
+    border-radius: 14px;
+    background: rgba(59, 130, 246, 0.08);
+    color: #1d4ed8;
+    font-weight: 500;
+    display: none;
+  }
+
+  .yc-status.error {
+    background: rgba(248, 113, 113, 0.14);
+    color: #b91c1c;
+  }
+
+  .yc-summary-grid {
+    margin-top: 28px;
+    display: grid;
+    gap: 14px;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  }
+
+  .yc-summary-card {
+    background: rgba(255, 255, 255, 0.92);
+    border-radius: 18px;
+    padding: 18px 20px;
+    box-shadow: 0 16px 38px rgba(15, 23, 42, 0.08);
+    border: 1px solid rgba(99, 102, 241, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    position: relative;
+    overflow: hidden;
+  }
+
+  .yc-summary-card::after {
+    content: "";
+    position: absolute;
+    inset: auto -40px -60px auto;
+    width: 110px;
+    height: 110px;
+    background: radial-gradient(circle at bottom right, rgba(99, 102, 241, 0.14), transparent 70%);
+  }
+
+  .yc-summary-card span {
+    text-transform: uppercase;
+    font-size: 0.78rem;
+    letter-spacing: 0.18em;
+    color: #6366f1;
+    font-weight: 600;
+  }
+
+  .yc-summary-card strong {
+    font-size: 1.65rem;
+    font-weight: 700;
+    color: #0b1736;
+  }
+
+  .yc-summary-card .delta {
+    font-size: 0.92rem;
+    font-weight: 500;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    color: #2563eb;
+  }
+
+  .yc-summary-card .delta.negative {
+    color: #dc2626;
+  }
+
+  .yc-layout {
+    margin-top: 36px;
+    display: grid;
+    gap: 24px;
+    grid-template-columns: minmax(0, 3fr) minmax(0, 2fr);
+  }
+
+  .yc-panel {
+    background: rgba(255, 255, 255, 0.95);
+    border-radius: 22px;
+    padding: 22px 24px 28px;
+    box-shadow: 0 14px 42px rgba(15, 23, 42, 0.08);
+    border: 1px solid rgba(148, 163, 184, 0.14);
+    display: flex;
+    flex-direction: column;
+    gap: 18px;
+  }
+
+  .yc-panel h2 {
+    font-size: 1.12rem;
+    margin: 0;
+    font-weight: 600;
+    color: #111827;
+  }
+
+  .yc-panel p {
+    margin: 0;
+    color: #5b6573;
+    font-size: 0.95rem;
+    line-height: 1.55;
+  }
+
+  .yc-panel canvas {
+    width: 100% !important;
+  }
+
+  .yc-panel .panel-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 14px;
+    font-size: 0.85rem;
+    color: #6b7280;
+  }
+
+  .yc-panel .legend-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .yc-panel .legend-dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 999px;
+  }
+
+  .yc-panel table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .yc-panel thead th {
+    text-align: left;
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    color: #6b7280;
+    padding-bottom: 10px;
+  }
+
+  .yc-panel tbody td {
+    padding: 9px 0;
+    border-top: 1px solid rgba(148, 163, 184, 0.18);
+    font-size: 0.95rem;
+    color: #1f2933;
+  }
+
+  .yc-panel tbody tr:first-of-type td {
+    border-top: none;
+    padding-top: 0;
+  }
+
+  .yc-panel tbody tr:last-of-type td {
+    padding-bottom: 0;
+  }
+
+  .yc-yield-table {
+    margin-top: 12px;
+    overflow-x: auto;
+  }
+
+  .yc-yield-table table {
+    min-width: 520px;
+  }
+
+  .yc-empty {
+    text-align: center;
+    padding: 24px;
+    background: rgba(15, 23, 42, 0.04);
+    border-radius: 16px;
+    color: #475569;
+  }
+
+  @media (max-width: 1100px) {
+    .yc-layout {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .yield-curves-app {
+      background: radial-gradient(circle at top left, rgba(15, 23, 42, 0.9) 0%, rgba(15, 23, 42, 0.94) 100%);
+      color: #f8fafc;
+      box-shadow: none;
+    }
+
+    .yield-curves-app h1 {
+      color: #e2e8f0;
+    }
+
+    .yield-curves-app .subhead {
+      color: #cbd5f5;
+    }
+
+    .yc-meta {
+      color: #a5b4fc;
+    }
+
+    .yc-meta .badge {
+      background: rgba(99, 102, 241, 0.18);
+      color: #c7d2fe;
+    }
+
+    .yc-summary-card {
+      background: rgba(30, 41, 59, 0.9);
+      border-color: rgba(99, 102, 241, 0.32);
+      box-shadow: none;
+    }
+
+    .yc-summary-card span {
+      color: #a5b4fc;
+    }
+
+    .yc-summary-card strong {
+      color: #f8fafc;
+    }
+
+    .yc-panel {
+      background: rgba(30, 41, 59, 0.88);
+      border-color: rgba(99, 102, 241, 0.22);
+      box-shadow: none;
+    }
+
+    .yc-panel h2 {
+      color: #e2e8f0;
+    }
+
+    .yc-panel p {
+      color: #cbd5f5;
+    }
+
+    .yc-panel thead th {
+      color: #cbd5f5;
+    }
+
+    .yc-panel tbody td {
+      color: #e2e8f0;
+      border-color: rgba(148, 163, 184, 0.22);
+    }
+
+    .yc-yield-table {
+      background: rgba(15, 23, 42, 0.35);
+      border-radius: 14px;
+      padding: 8px 14px;
+    }
+
+    .yc-empty {
+      background: rgba(148, 163, 184, 0.12);
+      color: #cbd5f5;
+    }
+  }
+</style>
+
+<div class="yield-curves-app" id="yield-curves-app">
+  <header>
+    <div class="badge">Fixed-Income Intelligence</div>
+    <h1>Yield Curve & Credit Spread Monitor</h1>
+    <p class="subhead">
+      Live US Treasury par yields alongside key corporate bond spreads to support asset-liability management and tactical asset allocation.
+      Trends are refreshed directly from the US Treasury and Federal Reserve (FRED).
+    </p>
+    <div class="yc-meta" data-role="meta">
+      <span><strong>Last refreshed:</strong> <time data-field="refreshed">—</time></span>
+      <span><strong>Data window:</strong> <span data-field="range">—</span></span>
+      <span class="badge">Netlify Functions</span>
+    </div>
+    <div class="yc-status" data-role="status">Loading market data…</div>
+  </header>
+
+  <section class="yc-summary-grid" data-section="summary">
+    <!-- Summary cards injected by script -->
+  </section>
+
+  <section class="yc-layout">
+    <article class="yc-panel">
+      <div>
+        <h2>Yield Curve Profiles</h2>
+        <p>Compare the latest Treasury curve with levels a month and a year ago to understand shifts in term premium and slope.</p>
+      </div>
+      <canvas id="yield-curve-chart" height="320"></canvas>
+      <div class="panel-meta" data-role="curve-meta"></div>
+    </article>
+
+    <article class="yc-panel">
+      <div>
+        <h2>Credit & Curve Spreads</h2>
+        <p>Track benchmark corporate bond spreads and the 10Y–2Y curve to gauge recession risk and relative value.</p>
+      </div>
+      <canvas id="spread-chart" height="320"></canvas>
+      <div class="panel-meta" data-role="spread-meta"></div>
+    </article>
+  </section>
+
+  <section class="yc-panel" style="margin-top: 28px;">
+    <div>
+      <h2>Recent Daily Treasury Par Yields</h2>
+      <p>An extract of the latest observations for quick reference across the curve.</p>
+    </div>
+    <div class="yc-yield-table" data-role="yield-table"></div>
+  </section>
+</div>
+
+<script>
+  (function () {
+    const state = {
+      data: null,
+      charts: {}
+    };
+
+    function hexToRgba(hex, alpha) {
+      if (!hex) return `rgba(99, 102, 241, ${alpha})`;
+      const sanitized = hex.replace('#', '');
+      const bigint = parseInt(sanitized.length === 3
+        ? sanitized.split('').map((c) => c + c).join('')
+        : sanitized, 16);
+      const r = (bigint >> 16) & 255;
+      const g = (bigint >> 8) & 255;
+      const b = bigint & 255;
+      return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+    }
+
+    const app = document.getElementById("yield-curves-app");
+    const summarySection = app.querySelector('[data-section="summary"]');
+    const statusBanner = app.querySelector('[data-role="status"]');
+    const metaFields = {
+      refreshed: app.querySelector('[data-field="refreshed"]'),
+      range: app.querySelector('[data-field="range"]')
+    };
+    const curveMeta = app.querySelector('[data-role="curve-meta"]');
+    const spreadMeta = app.querySelector('[data-role="spread-meta"]');
+    const tableContainer = app.querySelector('[data-role="yield-table"]');
+
+    function setStatus(message, type = "info") {
+      if (!statusBanner) return;
+      if (!message) {
+        statusBanner.style.display = "none";
+        return;
+      }
+      statusBanner.textContent = message;
+      statusBanner.classList.toggle("error", type === "error");
+      statusBanner.style.display = "block";
+    }
+
+    function formatPercent(value, decimals = 2) {
+      if (value === null || value === undefined || Number.isNaN(value)) return "—";
+      return `${value.toFixed(decimals)}%`;
+    }
+
+    function formatBps(value, decimals = 0) {
+      if (value === null || value === undefined || Number.isNaN(value)) return "—";
+      return `${value.toFixed(decimals)} bps`;
+    }
+
+    function calculateDelta(current, previous, unit = "percent") {
+      if (current === null || current === undefined || previous === null || previous === undefined) {
+        return { text: "", direction: "neutral" };
+      }
+      const change = current - previous;
+      if (Math.abs(change) < (unit === "bps" ? 1 : 0.01)) {
+        return { text: "Unchanged", direction: "neutral" };
+      }
+      const formatter = unit === "bps" ? formatBps : formatPercent;
+      return {
+        text: `${change > 0 ? "▲" : "▼"} ${formatter(Math.abs(change), unit === "bps" ? 0 : 2)}`,
+        direction: change > 0 ? "positive" : "negative"
+      };
+    }
+
+    function parseISO(dateStr) {
+      return dateStr ? new Date(`${dateStr}T00:00:00Z`) : null;
+    }
+
+    function findHistoricalPoint(series, lookbackDays) {
+      if (!Array.isArray(series) || !series.length) return null;
+      const latestDate = parseISO(series[series.length - 1].date);
+      if (!latestDate) return null;
+      const target = new Date(latestDate);
+      target.setUTCDate(target.getUTCDate() - lookbackDays);
+
+      for (let i = series.length - 1; i >= 0; i -= 1) {
+        const pointDate = parseISO(series[i].date);
+        if (!pointDate) continue;
+        const diffDays = (latestDate - pointDate) / (1000 * 60 * 60 * 24);
+        if (diffDays >= lookbackDays - 3) {
+          return series[i];
+        }
+      }
+      return series[0];
+    }
+
+    function buildSummaryCards(data) {
+      if (!summarySection) return;
+      summarySection.innerHTML = "";
+      const latest = data.treasury.series[data.treasury.series.length - 1];
+      const monthAgo = findHistoricalPoint(data.treasury.series, 30);
+      const yearAgo = findHistoricalPoint(data.treasury.series, 365);
+
+      const spreads = data.fred.reduce((acc, series) => {
+        acc[series.category] = series.data[series.data.length - 1]?.value ?? null;
+        acc[`${series.category}Prev`] = findHistoricalPoint(series.data, series.category === "tenTwoSpread" ? 30 : 30)?.value ?? null;
+        return acc;
+      }, {});
+
+      const cards = [
+        {
+          label: "10Y Treasury",
+          value: latest?.values?.["10y"],
+          previous: monthAgo?.values?.["10y"],
+          formatter: (value) => formatPercent(value ?? null, 2),
+          unit: "percent"
+        },
+        {
+          label: "2Y Treasury",
+          value: latest?.values?.["2y"],
+          previous: monthAgo?.values?.["2y"],
+          formatter: (value) => formatPercent(value ?? null, 2),
+          unit: "percent"
+        },
+        {
+          label: "10Y − 2Y Spread",
+          value: latest?.values?.["10y"] !== null && latest?.values?.["2y"] !== null
+            ? Math.round((latest.values["10y"] - latest.values["2y"]) * 100)
+            : null,
+          previous: monthAgo?.values?.["10y"] !== null && monthAgo?.values?.["2y"] !== null
+            ? Math.round((monthAgo.values["10y"] - monthAgo.values["2y"]) * 100)
+            : null,
+          formatter: (value) => formatBps(value ?? null, 0),
+          unit: "bps"
+        },
+        {
+          label: "IG Corporate OAS",
+          value: spreads.investmentGradeOas,
+          previous: spreads.investmentGradeOasPrev,
+          formatter: (value) => formatBps(value ?? null, 0),
+          unit: "bps"
+        },
+        {
+          label: "High Yield OAS",
+          value: spreads.highYieldOas,
+          previous: spreads.highYieldOasPrev,
+          formatter: (value) => formatBps(value ?? null, 0),
+          unit: "bps"
+        }
+      ];
+
+      cards.forEach((card) => {
+        const delta = calculateDelta(card.value, card.previous, card.unit === "bps" ? "bps" : "percent");
+        const cardEl = document.createElement("div");
+        cardEl.className = "yc-summary-card";
+
+        const labelEl = document.createElement("span");
+        labelEl.textContent = card.label;
+        cardEl.appendChild(labelEl);
+
+        const valueEl = document.createElement("strong");
+        valueEl.textContent = card.formatter(card.value);
+        cardEl.appendChild(valueEl);
+
+        if (delta.text) {
+          const deltaEl = document.createElement("div");
+          deltaEl.className = `delta${delta.direction === "negative" ? " negative" : ""}`;
+          deltaEl.textContent = delta.text;
+          cardEl.appendChild(deltaEl);
+        }
+
+        summarySection.appendChild(cardEl);
+      });
+    }
+
+    function buildCurveChart(data) {
+      const ctx = document.getElementById("yield-curve-chart");
+      if (!ctx) return;
+
+      const maturities = data.treasury.maturities.map((item) => item.label);
+      const latest = data.treasury.series[data.treasury.series.length - 1];
+      const monthAgo = findHistoricalPoint(data.treasury.series, 30);
+      const yearAgo = findHistoricalPoint(data.treasury.series, 365);
+
+      const datasetForPoint = (point, label, color) => ({
+        label,
+        data: data.treasury.maturities.map(({ key }) => point?.values?.[key] ?? null),
+        borderColor: color,
+        backgroundColor: hexToRgba(color, 0.18),
+        tension: 0.35,
+        fill: false,
+        spanGaps: true,
+        pointRadius: 4,
+        pointHoverRadius: 5,
+        borderWidth: 2
+      });
+
+      const chartData = {
+        labels: maturities,
+        datasets: [
+          datasetForPoint(yearAgo, `Year Ago (${yearAgo?.date ?? "—"})`, "#94a3b8"),
+          datasetForPoint(monthAgo, `30 Days Ago (${monthAgo?.date ?? "—"})`, "#6366f1"),
+          datasetForPoint(latest, `Latest (${latest?.date ?? "—"})`, "#2563eb")
+        ]
+      };
+
+      if (state.charts.curve) {
+        state.charts.curve.data = chartData;
+        state.charts.curve.update();
+      } else {
+        state.charts.curve = new Chart(ctx, {
+          type: "line",
+          data: chartData,
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+              y: {
+                title: {
+                  display: true,
+                  text: "Yield (%)"
+                },
+                ticks: {
+                  callback: (value) => `${value}%`
+                },
+                grid: {
+                  color: "rgba(148, 163, 184, 0.25)"
+                }
+              },
+              x: {
+                grid: {
+                  display: false
+                }
+              }
+            },
+            plugins: {
+              legend: {
+                position: "bottom"
+              },
+              tooltip: {
+                callbacks: {
+                  label: (context) => `${context.dataset.label}: ${formatPercent(context.parsed.y, 2)}`
+                }
+              }
+            }
+          }
+        });
+      }
+
+      if (curveMeta) {
+        curveMeta.innerHTML = `Curves plotted for <strong>${maturities.length}</strong> standard maturities. Data source: US Treasury.`;
+      }
+    }
+
+    function buildSpreadChart(data) {
+      const ctx = document.getElementById("spread-chart");
+      if (!ctx) return;
+      const colors = {
+        investmentGradeOas: "#6366f1",
+        highYieldOas: "#ec4899",
+        tenTwoSpread: "#14b8a6"
+      };
+
+      const datasets = data.fred.map((series) => ({
+        label: series.label,
+        data: series.data.map((point) => ({ x: point.date, y: point.value })),
+        borderColor: colors[series.category] || "#1f2937",
+        backgroundColor: hexToRgba(colors[series.category] || "#1f2937", 0.18),
+        tension: 0.3,
+        fill: false,
+        borderWidth: 2,
+        pointRadius: 0,
+        pointHoverRadius: 3
+      }));
+
+      const yLabel = (value, series) => {
+        if (series.category === "tenTwoSpread") {
+          return formatBps(value, 0);
+        }
+        return formatBps(value, 0);
+      };
+
+      if (state.charts.spread) {
+        state.charts.spread.data.datasets = datasets;
+        state.charts.spread.update();
+      } else {
+        state.charts.spread = new Chart(ctx, {
+          type: "line",
+          data: {
+            datasets
+          },
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+              x: {
+                type: "time",
+                adapters: {
+                  date: {
+                    zone: "utc"
+                  }
+                },
+                time: {
+                  tooltipFormat: "LLL dd, yyyy"
+                },
+                ticks: {
+                  maxRotation: 0,
+                  autoSkipPadding: 24
+                },
+                grid: {
+                  display: false
+                }
+              },
+              y: {
+                title: {
+                  display: true,
+                  text: "Basis Points"
+                },
+                ticks: {
+                  callback: (value) => `${value}`
+                },
+                grid: {
+                  color: "rgba(148, 163, 184, 0.24)"
+                }
+              }
+            },
+            plugins: {
+              legend: {
+                position: "bottom"
+              },
+              tooltip: {
+                callbacks: {
+                  label: (context) => {
+                    const series = data.fred[context.datasetIndex];
+                    return `${context.dataset.label}: ${yLabel(context.parsed.y, series)}`;
+                  }
+                }
+              }
+            }
+          }
+        });
+      }
+
+      if (spreadMeta) {
+        spreadMeta.innerHTML = `Spreads expressed in basis points. Source: FRED (ICE BofA) & Treasury.`;
+      }
+    }
+
+    function buildTable(data) {
+      if (!tableContainer) return;
+      const recent = [...data.treasury.series].slice(-7).reverse();
+      if (!recent.length) {
+        tableContainer.innerHTML = '<div class="yc-empty">No recent observations available.</div>';
+        return;
+      }
+
+      const headers = ["Date", ...data.treasury.maturities.map((item) => item.label)];
+      const table = document.createElement("table");
+      const thead = document.createElement("thead");
+      const headRow = document.createElement("tr");
+      headers.forEach((header) => {
+        const th = document.createElement("th");
+        th.textContent = header;
+        headRow.appendChild(th);
+      });
+      thead.appendChild(headRow);
+      table.appendChild(thead);
+
+      const tbody = document.createElement("tbody");
+      recent.forEach((row) => {
+        const tr = document.createElement("tr");
+        const dateCell = document.createElement("td");
+        dateCell.textContent = row.date;
+        tr.appendChild(dateCell);
+
+        data.treasury.maturities.forEach(({ key }) => {
+          const td = document.createElement("td");
+          const value = row.values?.[key];
+          td.textContent = value === null || value === undefined ? "—" : value.toFixed(2);
+          tr.appendChild(td);
+        });
+
+        tbody.appendChild(tr);
+      });
+
+      table.appendChild(tbody);
+      tableContainer.innerHTML = "";
+      tableContainer.appendChild(table);
+    }
+
+    function applyMeta(data) {
+      if (metaFields.refreshed) {
+        metaFields.refreshed.textContent = new Date(data.fetchedAt).toLocaleString(undefined, {
+          dateStyle: "medium",
+          timeStyle: "short"
+        });
+      }
+      if (metaFields.range) {
+        metaFields.range.textContent = `${data.rangeDays} calendar days`;
+      }
+    }
+
+    async function loadData() {
+      try {
+        setStatus("Loading market data…");
+        const response = await fetch("/.netlify/functions/yield-curves?range=720");
+        if (!response.ok) {
+          throw new Error(`Request failed: ${response.status}`);
+        }
+        const json = await response.json();
+        state.data = json;
+        applyMeta(json);
+        buildSummaryCards(json);
+        buildCurveChart(json);
+        buildSpreadChart(json);
+        buildTable(json);
+        setStatus("");
+      } catch (error) {
+        console.error(error);
+        setStatus("Unable to load live data. Please refresh or try again later.", "error");
+        tableContainer.innerHTML = '<div class="yc-empty">Live data unavailable. Check your connection or Netlify function logs.</div>';
+      }
+    }
+
+    loadData();
+  })();
+</script>

--- a/tools/yield-curves/index.qmd
+++ b/tools/yield-curves/index.qmd
@@ -1,0 +1,15 @@
+---
+title: "Yield Curve & Credit Spread Monitor"
+description: "Live US Treasury par yields with corporate spread context for insurance portfolio strategy."
+page-layout: full
+---
+
+{{< include app.html >}}
+
+## Preview Gallery
+
+Light and dark previews illustrate the design without executing the Netlify function.
+
+![Light mode preview of the Yield Curve & Credit Spread Monitor](preview-light.svg)
+
+![Dark mode preview of the Yield Curve & Credit Spread Monitor](preview-dark.svg)

--- a/tools/yield-curves/index.qmd
+++ b/tools/yield-curves/index.qmd
@@ -2,14 +2,7 @@
 title: "Yield Curve & Credit Spread Monitor"
 description: "Live US Treasury par yields with corporate spread context for insurance portfolio strategy."
 page-layout: full
+image: preview-dark.svg
 ---
 
 {{< include app.html >}}
-
-## Preview Gallery
-
-Light and dark previews illustrate the design without executing the Netlify function.
-
-![Light mode preview of the Yield Curve & Credit Spread Monitor](preview-light.svg)
-
-![Dark mode preview of the Yield Curve & Credit Spread Monitor](preview-dark.svg)

--- a/tools/yield-curves/preview-dark.svg
+++ b/tools/yield-curves/preview-dark.svg
@@ -1,0 +1,71 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 900" role="img" aria-labelledby="title desc">
+  <title id="title">Yield Curve &amp; Credit Spread Monitor preview (dark mode)</title>
+  <desc id="desc">A stylized mock-up of the tool UI displayed in dark theme.</desc>
+  <defs>
+    <linearGradient id="bgDark" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#111827" />
+      <stop offset="100%" stop-color="#0b1120" />
+    </linearGradient>
+    <linearGradient id="panelDark" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1e293b" />
+      <stop offset="100%" stop-color="#0f172a" />
+    </linearGradient>
+    <linearGradient id="cardDark" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#1e1b4b" />
+      <stop offset="100%" stop-color="#312e81" />
+    </linearGradient>
+  </defs>
+  <rect width="1440" height="900" rx="46" fill="url(#bgDark)" />
+  <g transform="translate(120 120)">
+    <rect x="0" y="0" width="320" height="46" rx="23" fill="rgba(99,102,241,0.25)" />
+    <text x="160" y="30" text-anchor="middle" font-family="Inter" font-size="22" fill="#c7d2fe">Fixed-Income Intelligence</text>
+    <text x="0" y="110" font-family="Inter" font-size="56" fill="#e2e8f0" font-weight="700">Yield Curve &amp; Credit Spread Monitor</text>
+    <text x="0" y="160" font-family="Inter" font-size="22" fill="#cbd5f5">Live Treasury yields with corporate spread context.</text>
+    <g transform="translate(0, 210)" font-family="Inter">
+      <g>
+        <rect x="0" y="0" width="240" height="160" rx="28" fill="url(#cardDark)" />
+        <text x="28" y="48" font-size="16" fill="#c7d2fe" letter-spacing="6">10Y TREASURY</text>
+        <text x="28" y="110" font-size="48" fill="#f8fafc" font-weight="700">4.38%</text>
+        <text x="28" y="146" font-size="20" fill="#60a5fa">▲ 12 bps</text>
+      </g>
+      <g transform="translate(260, 0)">
+        <rect x="0" y="0" width="240" height="160" rx="28" fill="url(#cardDark)" />
+        <text x="28" y="48" font-size="16" fill="#c7d2fe" letter-spacing="6">2Y TREASURY</text>
+        <text x="28" y="110" font-size="48" fill="#f8fafc" font-weight="700">4.56%</text>
+        <text x="28" y="146" font-size="20" fill="#f87171">▼ 6 bps</text>
+      </g>
+      <g transform="translate(520, 0)">
+        <rect x="0" y="0" width="240" height="160" rx="28" fill="url(#cardDark)" />
+        <text x="28" y="48" font-size="16" fill="#c7d2fe" letter-spacing="6">10Y − 2Y</text>
+        <text x="28" y="110" font-size="48" fill="#f8fafc" font-weight="700">−18 bps</text>
+        <text x="28" y="146" font-size="20" fill="#60a5fa">▲ 4 bps</text>
+      </g>
+      <g transform="translate(780, 0)">
+        <rect x="0" y="0" width="240" height="160" rx="28" fill="url(#cardDark)" />
+        <text x="28" y="48" font-size="16" fill="#c7d2fe" letter-spacing="6">IG OAS</text>
+        <text x="28" y="110" font-size="48" fill="#f8fafc" font-weight="700">131 bps</text>
+        <text x="28" y="146" font-size="20" fill="#60a5fa">▲ 3 bps</text>
+      </g>
+      <g transform="translate(1040, 0)">
+        <rect x="0" y="0" width="240" height="160" rx="28" fill="url(#cardDark)" />
+        <text x="28" y="48" font-size="16" fill="#c7d2fe" letter-spacing="6">HY OAS</text>
+        <text x="28" y="110" font-size="48" fill="#f8fafc" font-weight="700">342 bps</text>
+        <text x="28" y="146" font-size="20" fill="#f87171">▼ 8 bps</text>
+      </g>
+    </g>
+    <g transform="translate(0, 420)">
+      <rect width="820" height="320" rx="32" fill="url(#panelDark)" />
+      <text x="40" y="60" font-family="Inter" font-size="30" fill="#e2e8f0" font-weight="600">Yield Curve Profiles</text>
+      <polyline fill="none" stroke="#64748b" stroke-width="4" points="120,250 220,220 320,212 420,205 520,198 620,192 720,188" stroke-linecap="round" stroke-linejoin="round" />
+      <polyline fill="none" stroke="#818cf8" stroke-width="4" points="120,260 220,236 320,226 420,214 520,208 620,202 720,196" stroke-linecap="round" stroke-linejoin="round" />
+      <polyline fill="none" stroke="#3b82f6" stroke-width="4" points="120,272 220,245 320,230 420,220 520,210 620,204 720,198" stroke-linecap="round" stroke-linejoin="round" />
+    </g>
+    <g transform="translate(860, 420)">
+      <rect width="460" height="320" rx="32" fill="url(#panelDark)" />
+      <text x="40" y="60" font-family="Inter" font-size="30" fill="#e2e8f0" font-weight="600">Credit &amp; Curve Spreads</text>
+      <polyline fill="none" stroke="#818cf8" stroke-width="4" points="90,260 170,236 250,248 330,220 410,236" stroke-linecap="round" stroke-linejoin="round" />
+      <polyline fill="none" stroke="#f472b6" stroke-width="4" points="90,286 170,302 250,274 330,316 410,292" stroke-linecap="round" stroke-linejoin="round" />
+      <polyline fill="none" stroke="#2dd4bf" stroke-width="4" points="90,292 170,284 250,276 330,268 410,258" stroke-dasharray="14 12" stroke-linecap="round" stroke-linejoin="round" />
+    </g>
+  </g>
+</svg>

--- a/tools/yield-curves/preview-light.svg
+++ b/tools/yield-curves/preview-light.svg
@@ -1,0 +1,71 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 900" role="img" aria-labelledby="title desc">
+  <title id="title">Yield Curve &amp; Credit Spread Monitor preview (light mode)</title>
+  <desc id="desc">A stylized mock-up of the tool showing summary cards and two charts on a light background.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f6f8fc" />
+      <stop offset="100%" stop-color="#eef1f7" />
+    </linearGradient>
+    <linearGradient id="card" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffffff" />
+      <stop offset="100%" stop-color="#f7f7ff" />
+    </linearGradient>
+    <linearGradient id="panel" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ffffff" />
+      <stop offset="100%" stop-color="#f0f4ff" />
+    </linearGradient>
+  </defs>
+  <rect width="1440" height="900" fill="url(#bg)" rx="46" />
+  <g transform="translate(120 120)">
+    <rect x="0" y="0" width="280" height="42" rx="21" fill="#eef2ff" />
+    <text x="140" y="28" text-anchor="middle" font-family="Inter" font-size="20" fill="#4338ca">Fixed-Income Intelligence</text>
+    <text x="0" y="110" font-family="Inter" font-size="56" fill="#0b1736" font-weight="700">Yield Curve &amp; Credit Spread Monitor</text>
+    <text x="0" y="160" font-family="Inter" font-size="22" fill="#4b5563">Live Treasury yields with corporate spread context.</text>
+    <g transform="translate(0, 210)" font-family="Inter">
+      <g>
+        <rect x="0" y="0" width="240" height="160" rx="24" fill="url(#card)" />
+        <text x="28" y="48" font-size="16" fill="#6366f1" letter-spacing="6">10Y TREASURY</text>
+        <text x="28" y="110" font-size="48" fill="#0b1736" font-weight="700">4.38%</text>
+        <text x="28" y="146" font-size="20" fill="#2563eb">▲ 12 bps</text>
+      </g>
+      <g transform="translate(260, 0)">
+        <rect x="0" y="0" width="240" height="160" rx="24" fill="url(#card)" />
+        <text x="28" y="48" font-size="16" fill="#6366f1" letter-spacing="6">2Y TREASURY</text>
+        <text x="28" y="110" font-size="48" fill="#0b1736" font-weight="700">4.56%</text>
+        <text x="28" y="146" font-size="20" fill="#dc2626">▼ 6 bps</text>
+      </g>
+      <g transform="translate(520, 0)">
+        <rect x="0" y="0" width="240" height="160" rx="24" fill="url(#card)" />
+        <text x="28" y="48" font-size="16" fill="#6366f1" letter-spacing="6">10Y − 2Y</text>
+        <text x="28" y="110" font-size="48" fill="#0b1736" font-weight="700">−18 bps</text>
+        <text x="28" y="146" font-size="20" fill="#2563eb">▲ 4 bps</text>
+      </g>
+      <g transform="translate(780, 0)">
+        <rect x="0" y="0" width="240" height="160" rx="24" fill="url(#card)" />
+        <text x="28" y="48" font-size="16" fill="#6366f1" letter-spacing="6">IG OAS</text>
+        <text x="28" y="110" font-size="48" fill="#0b1736" font-weight="700">131 bps</text>
+        <text x="28" y="146" font-size="20" fill="#2563eb">▲ 3 bps</text>
+      </g>
+      <g transform="translate(1040, 0)">
+        <rect x="0" y="0" width="240" height="160" rx="24" fill="url(#card)" />
+        <text x="28" y="48" font-size="16" fill="#6366f1" letter-spacing="6">HY OAS</text>
+        <text x="28" y="110" font-size="48" fill="#0b1736" font-weight="700">342 bps</text>
+        <text x="28" y="146" font-size="20" fill="#dc2626">▼ 8 bps</text>
+      </g>
+    </g>
+    <g transform="translate(0, 420)">
+      <rect width="820" height="320" rx="28" fill="url(#panel)" />
+      <text x="36" y="52" font-family="Inter" font-size="28" fill="#0b1736" font-weight="600">Yield Curve Profiles</text>
+      <polyline fill="none" stroke="#94a3b8" stroke-width="4" points="100,250 220,220 340,210 460,205 580,198 700,190" stroke-linecap="round" stroke-linejoin="round" />
+      <polyline fill="none" stroke="#6366f1" stroke-width="4" points="100,260 220,230 340,220 460,210 580,200 700,192" stroke-linecap="round" stroke-linejoin="round" />
+      <polyline fill="none" stroke="#2563eb" stroke-width="4" points="100,270 220,240 340,225 460,215 580,205 700,198" stroke-linecap="round" stroke-linejoin="round" />
+    </g>
+    <g transform="translate(860, 420)">
+      <rect width="460" height="320" rx="28" fill="url(#panel)" />
+      <text x="36" y="52" font-family="Inter" font-size="28" fill="#0b1736" font-weight="600">Credit &amp; Curve Spreads</text>
+      <polyline fill="none" stroke="#6366f1" stroke-width="4" points="80,260 160,230 240,250 320,220 400,240" stroke-linecap="round" stroke-linejoin="round" />
+      <polyline fill="none" stroke="#ec4899" stroke-width="4" points="80,280 160,300 240,270 320,310 400,290" stroke-linecap="round" stroke-linejoin="round" />
+      <polyline fill="none" stroke="#14b8a6" stroke-width="4" points="80,290 160,280 240,270 320,260 400,250" stroke-dasharray="10 10" stroke-linecap="round" stroke-linejoin="round" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- add a Netlify Function that assembles the latest Treasury yield curve and key FRED credit spread series
- build a polished Yield Curve & Credit Spread Monitor tool with interactive charts, summary cards, and data table
- provide light and dark preview SVGs so the UI can be reviewed without running the function

## Testing
- not run (network access for live data fetches is restricted in the container)


------
https://chatgpt.com/codex/tasks/task_e_6903e932174883278db848a33dc41d21