### PR TITLE
Add Beazley to P&C dashboard universe

### DIFF
--- a/netlify/functions/pcd-dashboard.js
+++ b/netlify/functions/pcd-dashboard.js
@@ -46,6 +46,7 @@ const TICKERS = {
   WRB: "W. R. Berkley Corporation",
   WTM: "White Mountains Insurance Group",
   "ZURN.SW": "Zurich Insurance Group",
+  "BEZ.L": "Beazley plc",
   BOW: "Bowhead Specialty Holdings"
 };
 


### PR DESCRIPTION
## Summary
- add Beazley plc (BEZ.L) to the property & casualty dashboard ticker universe

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e4b4defc88327b70a12e1a261fe61)