### PR TITLE
Fix severe weather tracker date alignment

### DIFF
--- a/netlify/functions/spc-storm-reports.js
+++ b/netlify/functions/spc-storm-reports.js
@@ -260,6 +260,10 @@ function subtractDays(date, days) {
   return clone;
 }
 
+function toUtcDate(date) {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+}
+
 exports.handler = async (event) => {
   if (event.httpMethod === "OPTIONS") {
     return {
@@ -283,14 +287,12 @@ exports.handler = async (event) => {
 
   try {
     const requestedDate = resolveDateParameter(event);
-    const targetDate = new Date(Date.UTC(
-      requestedDate.getUTCFullYear(),
-      requestedDate.getUTCMonth(),
-      requestedDate.getUTCDate()
-    ));
+    const targetDate = toUtcDate(requestedDate);
+    const todayUtc = toUtcDate(new Date());
+    const shouldAttemptFallback = targetDate.getTime() === todayUtc.getTime();
 
     const fallbackDate = subtractDays(targetDate, 1);
-    const tries = [targetDate, fallbackDate];
+    const tries = shouldAttemptFallback ? [targetDate, fallbackDate] : [targetDate];
     let result = null;
     let usedDate = null;
 

--- a/tools/severe-weather-tracker/app.html
+++ b/tools/severe-weather-tracker/app.html
@@ -794,12 +794,14 @@
 
     function formatDisplayDate(iso) {
       if (!iso) return "";
-      const date = new Date(iso);
-      if (Number.isNaN(date.getTime())) return iso;
+      const [year, month, day] = iso.split("-").map((part) => Number.parseInt(part, 10));
+      if ([year, month, day].some((value) => Number.isNaN(value))) return iso;
+      const date = new Date(Date.UTC(year, month - 1, day));
       return date.toLocaleDateString(undefined, {
         month: "long",
         day: "numeric",
-        year: "numeric"
+        year: "numeric",
+        timeZone: "UTC"
       });
     }
 

--- a/tools/severe-weather-tracker/app.html
+++ b/tools/severe-weather-tracker/app.html
@@ -1122,6 +1122,9 @@
         setStatus(`<span class="swt-loader">Loading NOAA SPC reports…</span>`, false);
         const result = await fetchStormReports(dateValue);
         state.reportsResponse = result;
+        if (SELECTORS.dateInput && result?.date && SELECTORS.dateInput.value !== result.date) {
+          SELECTORS.dateInput.value = result.date;
+        }
         setStatus(`Loaded ${formatNumber(result.summary?.tornadoes + result.summary?.wind + result.summary?.hail)} preliminary reports.`, false);
         renderSummaryCards();
         renderMarkers();
@@ -1447,10 +1450,13 @@
     function setDefaultDate() {
       if (!SELECTORS.dateInput) return;
       const today = new Date();
-      const iso = formatIsoDate(today);
-      SELECTORS.dateInput.max = iso;
+      const yesterday = new Date(today);
+      yesterday.setDate(today.getDate() - 1);
+      const todayIso = formatIsoDate(today);
+      const yesterdayIso = formatIsoDate(yesterday);
+      SELECTORS.dateInput.max = todayIso;
       if (!SELECTORS.dateInput.value) {
-        SELECTORS.dateInput.value = iso;
+        SELECTORS.dateInput.value = yesterdayIso || todayIso;
       }
     }
 


### PR DESCRIPTION
## Summary
- ensure SPC storm report fallback only occurs for same-day requests so selected dates map to their data
- default the severe weather tracker date picker to yesterday and sync the control to the actual report date returned

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69499f5a4c9c83278ddf24616f76f41e)