### PR TITLE
Add state selector to tornado benchmark chart

### DIFF
--- a/netlify/functions/spc-tornado-trends.js
+++ b/netlify/functions/spc-tornado-trends.js
@@ -6,6 +6,61 @@ const MS_PER_DAY = 24 * 60 * 60 * 1000;
 const CURRENT_YEAR_CACHE = globalThis.__swtTornadoCurrentYearCache || new Map();
 globalThis.__swtTornadoCurrentYearCache = CURRENT_YEAR_CACHE;
 
+const STATE_NAMES = {
+  AL: "Alabama",
+  AK: "Alaska",
+  AZ: "Arizona",
+  AR: "Arkansas",
+  CA: "California",
+  CO: "Colorado",
+  CT: "Connecticut",
+  DE: "Delaware",
+  DC: "District of Columbia",
+  FL: "Florida",
+  GA: "Georgia",
+  HI: "Hawaii",
+  ID: "Idaho",
+  IL: "Illinois",
+  IN: "Indiana",
+  IA: "Iowa",
+  KS: "Kansas",
+  KY: "Kentucky",
+  LA: "Louisiana",
+  ME: "Maine",
+  MD: "Maryland",
+  MA: "Massachusetts",
+  MI: "Michigan",
+  MN: "Minnesota",
+  MS: "Mississippi",
+  MO: "Missouri",
+  MT: "Montana",
+  NE: "Nebraska",
+  NV: "Nevada",
+  NH: "New Hampshire",
+  NJ: "New Jersey",
+  NM: "New Mexico",
+  NY: "New York",
+  NC: "North Carolina",
+  ND: "North Dakota",
+  OH: "Ohio",
+  OK: "Oklahoma",
+  OR: "Oregon",
+  PA: "Pennsylvania",
+  PR: "Puerto Rico",
+  RI: "Rhode Island",
+  SC: "South Carolina",
+  SD: "South Dakota",
+  TN: "Tennessee",
+  TX: "Texas",
+  UT: "Utah",
+  VT: "Vermont",
+  VA: "Virginia",
+  WA: "Washington",
+  WV: "West Virginia",
+  WI: "Wisconsin",
+  WY: "Wyoming"
+};
+
 const SECTION_HEADERS = {
   tornado: /^Time\s*,\s*F_Scale/i,
   wind: /^Time\s*,\s*Speed/i,
@@ -79,10 +134,12 @@ function toDailyFilename(date) {
 }
 
 function parseDailyTornadoCount(csvText) {
-  if (!csvText) return 0;
+  if (!csvText) return { total: 0, byState: {} };
   const lines = csvText.split(/\r?\n/);
   let inTornadoSection = false;
-  let count = 0;
+  let total = 0;
+  const byState = new Map();
+  let tornadoHeader = [];
 
   for (const rawLine of lines) {
     const line = rawLine.trim();
@@ -90,6 +147,7 @@ function parseDailyTornadoCount(csvText) {
 
     if (SECTION_HEADERS.tornado.test(line)) {
       inTornadoSection = true;
+      tornadoHeader = splitCsvLine(line).map((col) => col.toLowerCase());
       continue;
     }
     if (SECTION_HEADERS.wind.test(line) || SECTION_HEADERS.hail.test(line)) {
@@ -98,11 +156,24 @@ function parseDailyTornadoCount(csvText) {
     }
 
     if (inTornadoSection) {
-      count += 1;
+      const parts = splitCsvLine(line);
+      if (!tornadoHeader.length) {
+        total += 1;
+        continue;
+      }
+      const stateIndex = tornadoHeader.indexOf("state");
+      const state = stateIndex >= 0 ? (parts[stateIndex] || "").trim().toUpperCase() : null;
+      total += 1;
+      if (state) {
+        byState.set(state, (byState.get(state) || 0) + 1);
+      }
     }
   }
 
-  return count;
+  return {
+    total,
+    byState: Object.fromEntries(byState)
+  };
 }
 
 async function fetchDailyTornadoCount(date) {
@@ -126,7 +197,7 @@ async function fetchDailyTornadoCount(date) {
       throw error;
     }
   }
-  return 0;
+  return { total: 0, byState: {} };
 }
 
 async function mapWithConcurrency(items, handler, limit = 6) {
@@ -160,6 +231,7 @@ async function buildCurrentYearSeriesFromDaily(year, todayUtc) {
 
   let series = [];
   let cumulative = 0;
+  const seriesByState = new Map();
   let fetchStartDate = new Date(startDate.getTime());
 
   if (cacheEntry && cacheEntry.lastDate) {
@@ -189,23 +261,39 @@ async function buildCurrentYearSeriesFromDaily(year, todayUtc) {
       return await fetchDailyTornadoCount(date);
     } catch (error) {
       if (error.statusCode === 404) {
-        return 0;
+        return { total: 0, byState: {} };
       }
       throw error;
     }
   });
 
   datesToFetch.forEach((date, idx) => {
-    const count = counts[idx] || 0;
+    const { total, byState } = counts[idx] || { total: 0, byState: {} };
     const dayOfYear = dayOfYearFromParts(date.getUTCFullYear(), date.getUTCMonth() + 1, date.getUTCDate());
-    cumulative += count;
+    cumulative += total;
     series.push({
       dayOfYear,
       date: formatIsoDate(date),
       cumulative,
-      daily: count,
+      daily: total,
       injuries: null,
       fatalities: null
+    });
+
+    Object.entries(byState || {}).forEach(([state, dailyCount]) => {
+      if (!seriesByState.has(state)) {
+        seriesByState.set(state, { cumulative: 0, series: [] });
+      }
+      const bucket = seriesByState.get(state);
+      bucket.cumulative += dailyCount;
+      bucket.series.push({
+        dayOfYear,
+        date: formatIsoDate(date),
+        cumulative: bucket.cumulative,
+        daily: dailyCount,
+        injuries: null,
+        fatalities: null
+      });
     });
   });
 
@@ -217,7 +305,22 @@ async function buildCurrentYearSeriesFromDaily(year, todayUtc) {
     fatalities: null,
     firstReportDate: series.length ? series[0].date : null,
     lastReportDate: series.length ? series[series.length - 1].date : null,
-    source: `${REPORTS_BASE_URL}YYMMDD_rpts.csv`
+    source: `${REPORTS_BASE_URL}YYMMDD_rpts.csv`,
+    byState: Object.fromEntries(
+      Array.from(seriesByState.entries()).map(([state, { series: stateSeries, cumulative: totalReports }]) => [
+        state,
+        {
+          state,
+          series: stateSeries,
+          totalReports,
+          injuries: null,
+          fatalities: null,
+          firstReportDate: stateSeries.length ? stateSeries[0].date : null,
+          lastReportDate: stateSeries.length ? stateSeries[stateSeries.length - 1].date : null,
+          source: `${REPORTS_BASE_URL}YYMMDD_rpts.csv`
+        }
+      ])
+    )
   };
 
   CURRENT_YEAR_CACHE.set(year, {
@@ -232,6 +335,37 @@ function parseInteger(value) {
   if (value == null || value === "") return 0;
   const numeric = Number.parseInt(value, 10);
   return Number.isFinite(numeric) ? numeric : 0;
+}
+
+function buildSeriesFromDailyMap(dailyMap, year) {
+  const sortedDays = Array.from(dailyMap.keys()).sort((a, b) => a - b);
+  let cumulative = 0;
+  let totalInjuries = 0;
+  let totalFatalities = 0;
+
+  const series = sortedDays.map((dayKey) => {
+    const { count, injuries, fatalities } = dailyMap.get(dayKey);
+    cumulative += count;
+    totalInjuries += injuries;
+    totalFatalities += fatalities;
+    return {
+      dayOfYear: dayKey,
+      date: isoFromDayOfYear(year, dayKey),
+      cumulative,
+      daily: count,
+      injuries,
+      fatalities
+    };
+  });
+
+  return {
+    series,
+    totalReports: cumulative,
+    injuries: totalInjuries,
+    fatalities: totalFatalities,
+    firstReportDate: sortedDays.length ? isoFromDayOfYear(year, sortedDays[0]) : null,
+    lastReportDate: sortedDays.length ? isoFromDayOfYear(year, sortedDays[sortedDays.length - 1]) : null
+  };
 }
 
 function parseTornadoYear(csvText, expectedYear) {
@@ -252,6 +386,7 @@ function parseTornadoYear(csvText, expectedYear) {
 
   const injuryIndex = indexByName.get("inj");
   const fatalityIndex = indexByName.get("fat");
+  const stateIndex = indexByName.get("st");
 
   const entries = [];
 
@@ -275,6 +410,7 @@ function parseTornadoYear(csvText, expectedYear) {
 
     const dayKey = dayOfYearFromParts(year, month, day);
     const isoDate = `${year}-${pad(month)}-${pad(day)}`;
+    const state = stateIndex != null ? (parts[stateIndex] || "").trim().toUpperCase() : null;
 
     entries.push({
       year,
@@ -283,7 +419,8 @@ function parseTornadoYear(csvText, expectedYear) {
       dayOfYear: dayKey,
       isoDate,
       injuries: injuryIndex != null ? parseInteger(parts[injuryIndex]) : 0,
-      fatalities: fatalityIndex != null ? parseInteger(parts[fatalityIndex]) : 0
+      fatalities: fatalityIndex != null ? parseInteger(parts[fatalityIndex]) : 0,
+      state
     });
   }
 
@@ -302,6 +439,7 @@ function parseTornadoYear(csvText, expectedYear) {
   entries.sort((a, b) => a.dayOfYear - b.dayOfYear);
 
   const daily = new Map();
+  const dailyByState = new Map();
   for (const entry of entries) {
     if (!daily.has(entry.dayOfYear)) {
       daily.set(entry.dayOfYear, {
@@ -314,39 +452,40 @@ function parseTornadoYear(csvText, expectedYear) {
     current.count += 1;
     current.injuries += entry.injuries;
     current.fatalities += entry.fatalities;
+
+    if (entry.state) {
+      if (!dailyByState.has(entry.state)) {
+        dailyByState.set(entry.state, new Map());
+      }
+      const stateMap = dailyByState.get(entry.state);
+      if (!stateMap.has(entry.dayOfYear)) {
+        stateMap.set(entry.dayOfYear, { count: 0, injuries: 0, fatalities: 0 });
+      }
+      const stateBucket = stateMap.get(entry.dayOfYear);
+      stateBucket.count += 1;
+      stateBucket.injuries += entry.injuries;
+      stateBucket.fatalities += entry.fatalities;
+    }
   }
 
-  const sortedDays = Array.from(daily.keys()).sort((a, b) => a - b);
-  let cumulative = 0;
-  let totalInjuries = 0;
-  let totalFatalities = 0;
-  const series = sortedDays.map((dayKey) => {
-    const { count, injuries, fatalities } = daily.get(dayKey);
-    cumulative += count;
-    totalInjuries += injuries;
-    totalFatalities += fatalities;
-    return {
-      dayOfYear: dayKey,
-      date: isoFromDayOfYear(expectedYear || entries[0].year, dayKey),
-      cumulative,
-      daily: count,
-      injuries,
-      fatalities
-    };
-  });
-
-  const firstDay = sortedDays[0];
-  const lastDay = sortedDays[sortedDays.length - 1];
   const seriesYear = expectedYear || entries[0].year;
+  const globalSeries = buildSeriesFromDailyMap(daily, seriesYear);
+  const byState = Object.fromEntries(
+    Array.from(dailyByState.entries()).map(([state, stateDaily]) => [
+      state,
+      {
+        state,
+        ...buildSeriesFromDailyMap(stateDaily, seriesYear),
+        source: `${TORNADO_BASE_URL}${seriesYear}_torn.csv`
+      }
+    ])
+  );
 
   return {
     year: seriesYear,
-    series,
-    totalReports: cumulative,
-    injuries: totalInjuries,
-    fatalities: totalFatalities,
-    firstReportDate: firstDay ? isoFromDayOfYear(seriesYear, firstDay) : null,
-    lastReportDate: lastDay ? isoFromDayOfYear(seriesYear, lastDay) : null
+    ...globalSeries,
+    byState,
+    source: `${TORNADO_BASE_URL}${seriesYear}_torn.csv`
   };
 }
 
@@ -407,6 +546,51 @@ function computeLatestPoint(series) {
   return series[series.length - 1];
 }
 
+function normalizeStateCode(code) {
+  if (!code) return null;
+  const normalized = code.trim().toUpperCase();
+  if (normalized === "ALL") return null;
+  return normalized;
+}
+
+function computeAvailableStates(seriesByYear) {
+  const stateSet = new Set();
+  seriesByYear.forEach((entry) => {
+    Object.keys(entry.byState || {}).forEach((code) => stateSet.add(code));
+  });
+  return Array.from(stateSet).sort();
+}
+
+function selectSeriesForState(seriesByYear, stateCode) {
+  const normalized = normalizeStateCode(stateCode);
+  if (!normalized) {
+    return {
+      selectedSeries: seriesByYear.map(({ byState, ...rest }) => rest),
+      stateLabel: "All States",
+      stateCode: null
+    };
+  }
+
+  const selectedSeries = seriesByYear
+    .map((entry) => {
+      const stateEntry = entry.byState?.[normalized];
+      if (!stateEntry || !stateEntry.series?.length) {
+        return null;
+      }
+      return {
+        ...stateEntry,
+        year: entry.year
+      };
+    })
+    .filter(Boolean);
+
+  return {
+    selectedSeries,
+    stateLabel: STATE_NAMES[normalized] || normalized,
+    stateCode: normalized
+  };
+}
+
 exports.handler = async (event) => {
   if (event.httpMethod === "OPTIONS") {
     return {
@@ -434,6 +618,7 @@ exports.handler = async (event) => {
     const requestedCurrentYear = Number.parseInt(params.currentYear, 10);
     const endYear = Number.isFinite(requestedCurrentYear) ? requestedCurrentYear : now.getUTCFullYear();
     const requestedStartYear = Number.parseInt(params.startYear, 10);
+    const requestedState = params.state ? params.state.trim().toUpperCase() : null;
 
     const startYear = Number.isFinite(requestedStartYear)
       ? Math.max(DEFAULT_START_YEAR, requestedStartYear)
@@ -500,20 +685,49 @@ exports.handler = async (event) => {
     }
 
     seriesByYear.sort((a, b) => a.year - b.year);
+    const availableStates = computeAvailableStates(seriesByYear);
+    if (requestedState && requestedState !== "ALL") {
+      if (STATE_NAMES[requestedState] == null && !availableStates.includes(requestedState)) {
+        return {
+          statusCode: 400,
+          headers: {
+            "Content-Type": "application/json",
+            "Access-Control-Allow-Origin": "*"
+          },
+          body: JSON.stringify({ error: `Unsupported state code: ${requestedState}` })
+        };
+      }
+    }
 
-    const availableYears = seriesByYear.map((item) => item.year);
+    const { selectedSeries, stateLabel, stateCode } = selectSeriesForState(seriesByYear, requestedState);
+    if (!selectedSeries.length) {
+      return {
+        statusCode: 404,
+        headers: {
+          "Content-Type": "application/json",
+          "Access-Control-Allow-Origin": "*"
+        },
+        body: JSON.stringify({
+          error: "No tornado history datasets were available for the requested state and range.",
+          range: { startYear, endYear },
+          state: requestedState || "ALL"
+        })
+      };
+    }
+
+    const availableYears = selectedSeries.map((item) => item.year);
     const currentYear = calendarCurrentYear;
     const comparisonYearCandidate = currentYear - 1;
     const comparisonYear = availableYears.includes(comparisonYearCandidate)
       ? comparisonYearCandidate
       : null;
 
-    const currentSeries = seriesByYear.find((item) => item.year === currentYear)
-      || seriesByYear.find((item) => item.year === availableYears[availableYears.length - 1]);
+    const currentSeries = selectedSeries.find((item) => item.year === currentYear)
+      || selectedSeries.find((item) => item.year === availableYears[availableYears.length - 1]);
     const comparisonSeries = comparisonYear
-      ? seriesByYear.find((item) => item.year === comparisonYear)
+      ? selectedSeries.find((item) => item.year === comparisonYear)
       : null;
-    const ensembleStats = computeEnsembleStats(seriesByYear, currentYear, comparisonYear);
+    const ensembleStats = computeEnsembleStats(selectedSeries, currentYear, comparisonYear);
     const currentLatestPoint = computeLatestPoint(currentSeries?.series || []);
     const primarySource =
       currentSeries?.source ||
@@ -535,9 +749,15 @@ exports.handler = async (event) => {
         comparisonYear,
         currentLatestPoint,
         ensembleStats,
-        years: seriesByYear,
+        years: selectedSeries,
         missingYears: errors,
-        notes: "Data represents preliminary tornado reports as published by SPC. Counts are cumulative by day of year."
+        notes: "Data represents preliminary tornado reports as published by SPC. Counts are cumulative by day of year.",
+        stateCode,
+        stateLabel,
+        availableStates: availableStates.map((code) => ({
+          code,
+          name: STATE_NAMES[code] || code
+        }))
       })
     };
   } catch (error) {

--- a/tools/severe-weather-tracker/app.html
+++ b/tools/severe-weather-tracker/app.html
@@ -97,7 +97,8 @@
     margin-bottom: 8px;
   }
 
-  .swt-input {
+  .swt-input,
+  .swt-select {
     width: 220px;
     font-size: 1rem;
     padding: 10px 14px;
@@ -109,7 +110,8 @@
     transition: border-color 0.2s ease, box-shadow 0.2s ease;
   }
 
-  .swt-input:focus {
+  .swt-input:focus,
+  .swt-select:focus {
     border-color: rgba(59, 130, 246, 0.6);
     box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.15);
   }
@@ -617,8 +619,10 @@
       activeTypes: new Set(["tornado", "wind", "hail"]),
       reportsResponse: null,
       tornadoResponse: null,
-    chart: null
-  };
+      selectedState: "ALL",
+      availableStates: [],
+      chart: null
+    };
     const CHART_ANCHOR_YEAR = 2000;
     const Y_AXIS_MAX = 2000;
 
@@ -654,6 +658,12 @@
               <button type="button" class="swt-toggle is-active" data-type="wind">Wind</button>
               <button type="button" class="swt-toggle is-active" data-type="hail">Hail</button>
             </div>
+          </div>
+          <div class="swt-control-card">
+            <label for="swt-state-select">Tornado Benchmark Region</label>
+            <select id="swt-state-select" class="swt-select" aria-label="Select state for tornado benchmark">
+              <option value="ALL">All states</option>
+            </select>
           </div>
         </section>
         <div class="swt-status" id="swt-status" role="status"></div>
@@ -717,6 +727,7 @@
           dateInput: root.querySelector("#swt-date-input"),
           status: root.querySelector("#swt-status"),
           toggleButtons: Array.from(root.querySelectorAll(".swt-toggle")),
+          stateSelect: root.querySelector("#swt-state-select"),
           mapSummary: root.querySelector("#swt-map-summary"),
           summaryDate: root.querySelector("#swt-summary-date"),
           mapSource: root.querySelector("#swt-map-source"),
@@ -1094,8 +1105,12 @@
       return response.json();
     }
 
-    async function fetchTornadoTrends() {
-      const response = await fetch(API_ENDPOINTS.tornado);
+    async function fetchTornadoTrends(stateCode) {
+      const url = new URL(API_ENDPOINTS.tornado, window.location.origin);
+      if (stateCode && stateCode !== "ALL") {
+        url.searchParams.set("state", stateCode);
+      }
+      const response = await fetch(url.toString());
       if (!response.ok) {
         const text = await response.text();
         throw new Error(text || `Failed to load tornado history (${response.status})`);
@@ -1227,6 +1242,7 @@
       target.innerHTML = "";
 
       const { currentYear, comparisonYear, currentLatestPoint, years, ensembleStats } = data;
+      const regionLabel = data.stateLabel || "All states";
       const comparisonSeries = years.find((entry) => entry.year === comparisonYear);
       const currentSeries = years.find((entry) => entry.year === currentYear);
       const dayOfYear = currentLatestPoint?.dayOfYear;
@@ -1236,19 +1252,19 @@
         {
           label: `${currentYear} Reports`,
           value: formatNumber(currentLatestPoint?.cumulative || 0),
-          detail: `As of ${formatDisplayDate(currentLatestPoint?.date) || "latest available"}`
+          detail: `${regionLabel} • As of ${formatDisplayDate(currentLatestPoint?.date) || "latest available"}`
         },
         {
           label: `${comparisonYear || currentYear - 1} Reports`,
           value: formatNumber(comparisonPoint?.cumulative || comparisonSeries?.totalReports || 0),
           detail: comparisonPoint
-            ? `Same time last year`
-            : `Total for ${comparisonYear || currentYear - 1}`
+            ? `Same time last year • ${regionLabel}`
+            : `Total for ${comparisonYear || currentYear - 1} • ${regionLabel}`
         },
         {
           label: "Historical Average",
           value: formatNumber(Math.round(ensembleStats?.averageTotal || 0)),
-          detail: `${ensembleStats?.count || 0} seasons since ${data.startYear}`
+          detail: `${regionLabel} • ${ensembleStats?.count || 0} seasons since ${data.startYear}`
         }
       ];
 
@@ -1270,6 +1286,7 @@
       target.innerHTML = "";
 
       const { currentYear, currentLatestPoint, comparisonYear, years } = data;
+      const regionLabel = data.stateLabel || "All states";
       const comparisonSeries = years.find((entry) => entry.year === comparisonYear);
       const comparisonPoint = comparisonSeries
         ? findValueOnOrBefore(comparisonSeries.series, currentLatestPoint?.dayOfYear || 0)
@@ -1291,7 +1308,7 @@
 
       const paragraph = document.createElement("p");
       paragraph.innerHTML = `
-        <strong>${currentYear} tornado reports:</strong> ${formatNumber(currentLatestPoint?.cumulative || 0)} total as of ${formatDisplayDate(currentLatestPoint?.date)} — ${diffText}.
+        <strong>${currentYear} ${regionLabel} tornado reports:</strong> ${formatNumber(currentLatestPoint?.cumulative || 0)} total as of ${formatDisplayDate(currentLatestPoint?.date)} — ${diffText}.
       `;
       target.appendChild(paragraph);
     }
@@ -1307,8 +1324,14 @@
       const ctx = SELECTORS.chartCanvas.getContext("2d");
       if (!ctx) return;
 
-      const ySuggestedMax = Y_AXIS_MAX;
-      const tickStep = 200;
+      const maxValue = datasets.reduce((max, ds) => {
+        const datasetMax = ds.data.reduce((dMax, point) => Math.max(dMax, point.y || 0), 0);
+        return Math.max(max, datasetMax);
+      }, 0);
+
+      const suggestedCeiling = Math.ceil((maxValue || 0) / 100) * 100 + 100;
+      const ySuggestedMax = Math.min(Y_AXIS_MAX, Math.max(400, suggestedCeiling));
+      const tickStep = ySuggestedMax > 800 ? 200 : 100;
 
       if (state.chart) {
         state.chart.destroy();
@@ -1429,11 +1452,30 @@
       }
     }
 
+    function populateStateOptions(result) {
+      const select = SELECTORS.stateSelect;
+      if (!select || !Array.isArray(result?.availableStates)) return;
+      if (select.dataset.populated !== "true") {
+        const fragment = document.createDocumentFragment();
+        result.availableStates.forEach((state) => {
+          const option = document.createElement("option");
+          option.value = state.code;
+          option.textContent = state.name || state.code;
+          fragment.appendChild(option);
+        });
+        select.appendChild(fragment);
+        select.dataset.populated = "true";
+      }
+      select.value = state.selectedState || "ALL";
+    }
+
     async function loadTornadoHistory() {
       try {
         SELECTORS.chartMeta.innerHTML = `<span class="swt-loader">Loading tornado history…</span>`;
-        const result = await fetchTornadoTrends();
+        const result = await fetchTornadoTrends(state.selectedState);
         state.tornadoResponse = result;
+        state.availableStates = result.availableStates || [];
+        populateStateOptions(result);
         renderTornadoChart();
         renderChartMeta(result);
         renderChartSummary(result);
@@ -1476,6 +1518,12 @@
 
       SELECTORS.dateInput?.addEventListener("change", () => {
         loadStormReports();
+        loadTornadoHistory();
+      });
+
+      SELECTORS.stateSelect?.addEventListener("change", (event) => {
+        const value = event.target.value || "ALL";
+        state.selectedState = value;
         loadTornadoHistory();
       });
     }

--- a/tools/severe-weather-tracker/app.html
+++ b/tools/severe-weather-tracker/app.html
@@ -121,6 +121,20 @@
     gap: 10px;
   }
 
+  .swt-chart-filters {
+    margin-top: 12px;
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+
+  .swt-chart-filters label {
+    font-size: 0.92rem;
+    color: #475569;
+    font-weight: 600;
+  }
+
   .swt-toggle {
     display: inline-flex;
     align-items: center;
@@ -659,12 +673,6 @@
               <button type="button" class="swt-toggle is-active" data-type="hail">Hail</button>
             </div>
           </div>
-          <div class="swt-control-card">
-            <label for="swt-state-select">Tornado Benchmark Region</label>
-            <select id="swt-state-select" class="swt-select" aria-label="Select state for tornado benchmark">
-              <option value="ALL">All states</option>
-            </select>
-          </div>
         </section>
         <div class="swt-status" id="swt-status" role="status"></div>
         <section class="swt-map-section" aria-label="Storm detail">
@@ -698,6 +706,12 @@
         </section>
         <section class="swt-chart-panel" aria-label="Tornado trends">
           <h2>Tornado Activity Benchmark</h2>
+          <div class="swt-chart-filters">
+            <label for="swt-state-select">Benchmark region:</label>
+            <select id="swt-state-select" class="swt-select" aria-label="Select state for tornado benchmark">
+              <option value="ALL">All states</option>
+            </select>
+          </div>
           <div class="swt-chart-meta" id="swt-chart-meta">
             <span class="swt-loader">Loading tornado history…</span>
           </div>
@@ -1329,9 +1343,11 @@
         return Math.max(max, datasetMax);
       }, 0);
 
-      const suggestedCeiling = Math.ceil((maxValue || 0) / 100) * 100 + 100;
-      const ySuggestedMax = Math.min(Y_AXIS_MAX, Math.max(400, suggestedCeiling));
-      const tickStep = ySuggestedMax > 800 ? 200 : 100;
+      const margin = Math.max(50, maxValue * 0.12);
+      const suggestedCeiling = maxValue + margin;
+      const roundedCeiling = Math.max(100, Math.ceil(suggestedCeiling / 50) * 50);
+      const ySuggestedMax = roundedCeiling;
+      const tickStep = ySuggestedMax > 1000 ? 200 : ySuggestedMax > 400 ? 100 : 50;
 
       if (state.chart) {
         state.chart.destroy();


### PR DESCRIPTION
## Summary
- compute tornado benchmark data per-state in the Netlify function and expose available states to the client
- add a state dropdown to the severe weather tracker tornado chart and feed the selection into fetches and summaries
- tune chart scaling and copy to reflect the selected region

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6949a0ae56a08327ab844991e4dab9df)