### PR TITLE
Fix tornado trend chart date parsing

### DIFF
--- a/tools/severe-weather-tracker/app.html
+++ b/tools/severe-weather-tracker/app.html
@@ -789,7 +789,7 @@
       if (Number.isNaN(date.getTime())) return null;
       const month = date.getUTCMonth();
       const day = date.getUTCDate();
-      return new Date(Date.UTC(CHART_ANCHOR_YEAR, month, day));
+      return Date.UTC(CHART_ANCHOR_YEAR, month, day);
     }
 
     function formatDisplayDate(iso) {
@@ -1138,8 +1138,8 @@
       }
     }
 
-    const CHART_AXIS_MIN = new Date(Date.UTC(CHART_ANCHOR_YEAR, 0, 1));
-    const CHART_AXIS_MAX = new Date(Date.UTC(CHART_ANCHOR_YEAR, 11, 31));
+    const CHART_AXIS_MIN = Date.UTC(CHART_ANCHOR_YEAR, 0, 1);
+    const CHART_AXIS_MAX = Date.UTC(CHART_ANCHOR_YEAR, 11, 31);
 
     function buildChartDatasets(data) {
       const { years, currentYear, comparisonYear } = data;


### PR DESCRIPTION
## Summary
- normalize tornado chart dates to UTC timestamps to satisfy the Luxon adapter
- align chart axis bounds with timestamp values to prevent tooltip errors

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694acfdd4fa883278475a34e8145a058)