### PR TITLE
Add 2025 U.S. tornado season year-in-review blog post

### DIFF
--- a/posts/2026-01-13-2025-tornado-year-in-review/index.qmd
+++ b/posts/2026-01-13-2025-tornado-year-in-review/index.qmd
@@ -26,7 +26,7 @@ since 2011, tornado activity moderated significantly in the second half of the y
 
 <script>
 (function() {
-  const { useState, useEffect, createElement: h } = React;
+  const { useState, useEffect, useRef, createElement: h } = React;
 
   const monthlyData = [
     { month: 'Jan', tornadoes: 16, avg: 35, status: 'below' },
@@ -42,6 +42,14 @@ since 2011, tornado activity moderated significantly in the second half of the y
     { month: 'Nov', tornadoes: 10, avg: 52, status: 'below' },
     { month: 'Dec', tornadoes: 15, avg: 24, status: 'below' },
   ];
+
+  // Cumulative data for the line chart (approximate weekly data points)
+  const cumulativeData = {
+    labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+    year2025: [16, 55, 294, 609, 1014, 1296, 1391, 1444, 1504, 1530, 1540, 1555],
+    year2024: [75, 176, 295, 545, 922, 1224, 1377, 1484, 1576, 1670, 1741, 1796],
+    average: [35, 64, 144, 299, 575, 818, 912, 985, 1054, 1110, 1162, 1186],
+  };
 
   const yearlyComparison = [
     { year: '2011', tornadoes: 1691, deaths: 553, highlight: false },
@@ -59,14 +67,14 @@ since 2011, tornado activity moderated significantly in the second half of the y
     { date: 'Dec 28', event: 'Late Season Outbreak', tornadoes: 15, description: 'Illinois outbreak including an EF-2 with 120 mph winds' },
   ];
 
-  const totalTornadoes = monthlyData.reduce((sum, m) => sum + m.tornadoes, 0);
-  const totalAvg = monthlyData.reduce((sum, m) => sum + m.avg, 0);
   const maxMonth = Math.max(...monthlyData.map(m => m.tornadoes));
 
   function TornadoReviewApp() {
     const [hoveredMonth, setHoveredMonth] = useState(null);
-    const [activeTab, setActiveTab] = useState('monthly');
+    const [hoveredPoint, setHoveredPoint] = useState(null);
+    const [activeTab, setActiveTab] = useState('cumulative');
     const [animated, setAnimated] = useState(false);
+    const svgRef = useRef(null);
 
     useEffect(() => {
       const timer = setTimeout(() => setAnimated(true), 100);
@@ -167,6 +175,7 @@ since 2011, tornado activity moderated significantly in the second half of the y
         background: 'rgba(255,255,255,0.03)',
         borderRadius: '12px',
         width: 'fit-content',
+        flexWrap: 'wrap',
       },
       tab: {
         padding: '10px 20px',
@@ -182,15 +191,15 @@ since 2011, tornado activity moderated significantly in the second half of the y
         borderRadius: '20px',
         border: '1px solid rgba(255,255,255,0.06)',
         padding: '24px',
-        overflow: 'hidden',
       },
       monthlyChart: {
         display: 'flex',
         alignItems: 'flex-end',
         justifyContent: 'space-between',
-        height: '300px',
+        height: '340px',
         gap: '8px',
-        paddingTop: '40px',
+        paddingTop: '60px',
+        position: 'relative',
       },
       barGroup: {
         flex: 1,
@@ -199,6 +208,7 @@ since 2011, tornado activity moderated significantly in the second half of the y
         alignItems: 'center',
         gap: '8px',
         cursor: 'pointer',
+        position: 'relative',
       },
       barContainer: {
         width: '100%',
@@ -229,16 +239,17 @@ since 2011, tornado activity moderated significantly in the second half of the y
       },
       tooltip: {
         position: 'absolute',
-        bottom: '100%',
+        bottom: 'calc(100% + 10px)',
         left: '50%',
         transform: 'translateX(-50%)',
-        background: 'rgba(15, 23, 42, 0.95)',
+        background: 'rgba(15, 23, 42, 0.98)',
         padding: '12px 16px',
         borderRadius: '8px',
-        border: '1px solid rgba(255,255,255,0.1)',
+        border: '1px solid rgba(255,255,255,0.15)',
         whiteSpace: 'nowrap',
-        zIndex: 10,
-        marginBottom: '8px',
+        zIndex: 1000,
+        boxShadow: '0 4px 20px rgba(0,0,0,0.4)',
+        pointerEvents: 'none',
       },
       eventCard: {
         background: 'rgba(255,255,255,0.02)',
@@ -285,6 +296,242 @@ since 2011, tornado activity moderated significantly in the second half of the y
       { label: 'EF5 Tornadoes', value: '1', sublabel: 'First since 2013', color: '#dc2626' },
     ];
 
+    // SVG Line Chart for cumulative data
+    const renderCumulativeChart = () => {
+      const width = 1000;
+      const height = 400;
+      const padding = { top: 40, right: 120, bottom: 50, left: 60 };
+      const chartWidth = width - padding.left - padding.right;
+      const chartHeight = height - padding.top - padding.bottom;
+
+      const maxY = 2000;
+      const yScale = (val) => padding.top + chartHeight - (val / maxY) * chartHeight;
+      const xScale = (idx) => padding.left + (idx / (cumulativeData.labels.length - 1)) * chartWidth;
+
+      const createPath = (data) => {
+        return data.map((val, idx) => {
+          const x = xScale(idx);
+          const y = yScale(val);
+          return `${idx === 0 ? 'M' : 'L'} ${x} ${y}`;
+        }).join(' ');
+      };
+
+      const gridLines = [0, 400, 800, 1200, 1600, 2000];
+
+      return h('div', { style: { position: 'relative' } },
+        h('svg', {
+          ref: svgRef,
+          viewBox: `0 0 ${width} ${height}`,
+          style: { width: '100%', height: 'auto', minHeight: '350px' },
+          onMouseMove: (e) => {
+            if (!svgRef.current) return;
+            const rect = svgRef.current.getBoundingClientRect();
+            const x = (e.clientX - rect.left) * (width / rect.width);
+            const idx = Math.round((x - padding.left) / chartWidth * (cumulativeData.labels.length - 1));
+            if (idx >= 0 && idx < cumulativeData.labels.length) {
+              setHoveredPoint(idx);
+            }
+          },
+          onMouseLeave: () => setHoveredPoint(null),
+        },
+          // Grid lines
+          gridLines.map(val =>
+            h('g', { key: val },
+              h('line', {
+                x1: padding.left,
+                y1: yScale(val),
+                x2: width - padding.right,
+                y2: yScale(val),
+                stroke: 'rgba(148, 163, 184, 0.15)',
+                strokeDasharray: val === 0 ? 'none' : '4,4',
+              }),
+              h('text', {
+                x: padding.left - 10,
+                y: yScale(val),
+                fill: '#64748b',
+                fontSize: '12',
+                textAnchor: 'end',
+                dominantBaseline: 'middle',
+              }, val.toLocaleString())
+            )
+          ),
+
+          // X-axis labels
+          cumulativeData.labels.map((label, idx) =>
+            h('text', {
+              key: label,
+              x: xScale(idx),
+              y: height - padding.bottom + 25,
+              fill: '#64748b',
+              fontSize: '12',
+              textAnchor: 'middle',
+            }, label)
+          ),
+
+          // Historical average area (shaded)
+          h('path', {
+            d: `${createPath(cumulativeData.average)} L ${xScale(11)} ${yScale(0)} L ${xScale(0)} ${yScale(0)} Z`,
+            fill: 'rgba(148, 163, 184, 0.08)',
+          }),
+
+          // Historical average line
+          h('path', {
+            d: createPath(cumulativeData.average),
+            fill: 'none',
+            stroke: 'rgba(148, 163, 184, 0.5)',
+            strokeWidth: '2',
+            strokeDasharray: '6,4',
+          }),
+
+          // 2024 line
+          h('path', {
+            d: createPath(cumulativeData.year2024),
+            fill: 'none',
+            stroke: '#64748b',
+            strokeWidth: '2.5',
+            strokeDasharray: '8,6',
+            className: animated ? 'line-animate' : '',
+          }),
+
+          // 2025 line (main)
+          h('path', {
+            d: createPath(cumulativeData.year2025),
+            fill: 'none',
+            stroke: '#ef4444',
+            strokeWidth: '3',
+            className: animated ? 'line-animate' : '',
+          }),
+
+          // End point markers and labels
+          // 2025 end point
+          h('circle', {
+            cx: xScale(11),
+            cy: yScale(cumulativeData.year2025[11]),
+            r: 6,
+            fill: '#ef4444',
+          }),
+          h('rect', {
+            x: xScale(11) + 12,
+            y: yScale(cumulativeData.year2025[11]) - 14,
+            width: 95,
+            height: 28,
+            rx: 6,
+            fill: 'rgba(239, 68, 68, 0.15)',
+            stroke: '#ef4444',
+            strokeWidth: 1,
+          }),
+          h('text', {
+            x: xScale(11) + 60,
+            y: yScale(cumulativeData.year2025[11]),
+            fill: '#ef4444',
+            fontSize: '13',
+            fontWeight: '600',
+            textAnchor: 'middle',
+            dominantBaseline: 'middle',
+          }, '2025: 1,555'),
+
+          // 2024 end point
+          h('circle', {
+            cx: xScale(11),
+            cy: yScale(cumulativeData.year2024[11]),
+            r: 5,
+            fill: '#64748b',
+          }),
+          h('text', {
+            x: xScale(11) + 15,
+            y: yScale(cumulativeData.year2024[11]),
+            fill: '#94a3b8',
+            fontSize: '12',
+            fontWeight: '500',
+            dominantBaseline: 'middle',
+          }, '2024: 1,796'),
+
+          // Average end label
+          h('text', {
+            x: xScale(11) + 15,
+            y: yScale(cumulativeData.average[11]),
+            fill: '#64748b',
+            fontSize: '12',
+            dominantBaseline: 'middle',
+          }, 'Avg: 1,186'),
+
+          // Hover line and tooltip
+          hoveredPoint !== null && h('g', null,
+            h('line', {
+              x1: xScale(hoveredPoint),
+              y1: padding.top,
+              x2: xScale(hoveredPoint),
+              y2: height - padding.bottom,
+              stroke: 'rgba(255,255,255,0.3)',
+              strokeWidth: 1,
+              strokeDasharray: '4,4',
+            }),
+            h('circle', {
+              cx: xScale(hoveredPoint),
+              cy: yScale(cumulativeData.year2025[hoveredPoint]),
+              r: 6,
+              fill: '#ef4444',
+              stroke: '#fff',
+              strokeWidth: 2,
+            }),
+            h('circle', {
+              cx: xScale(hoveredPoint),
+              cy: yScale(cumulativeData.year2024[hoveredPoint]),
+              r: 5,
+              fill: '#64748b',
+              stroke: '#fff',
+              strokeWidth: 2,
+            }),
+            h('circle', {
+              cx: xScale(hoveredPoint),
+              cy: yScale(cumulativeData.average[hoveredPoint]),
+              r: 4,
+              fill: 'rgba(148, 163, 184, 0.8)',
+              stroke: '#fff',
+              strokeWidth: 2,
+            })
+          )
+        ),
+
+        // Tooltip overlay
+        hoveredPoint !== null && h('div', {
+          style: {
+            position: 'absolute',
+            left: '50%',
+            top: '20px',
+            transform: 'translateX(-50%)',
+            background: 'rgba(15, 23, 42, 0.95)',
+            padding: '16px 20px',
+            borderRadius: '12px',
+            border: '1px solid rgba(255,255,255,0.15)',
+            boxShadow: '0 4px 20px rgba(0,0,0,0.4)',
+            zIndex: 100,
+          }
+        },
+          h('div', { style: { color: '#f8fafc', fontWeight: '600', marginBottom: '12px', fontSize: '14px' } },
+            `End of ${cumulativeData.labels[hoveredPoint]} (Cumulative)`
+          ),
+          h('div', { style: { display: 'grid', gap: '8px' } },
+            h('div', { style: { display: 'flex', alignItems: 'center', gap: '8px' } },
+              h('div', { style: { width: '12px', height: '3px', background: '#ef4444', borderRadius: '2px' } }),
+              h('span', { style: { color: '#ef4444', fontWeight: '600', fontFamily: "'JetBrains Mono', monospace" } },
+                `2025: ${cumulativeData.year2025[hoveredPoint].toLocaleString()}`)
+            ),
+            h('div', { style: { display: 'flex', alignItems: 'center', gap: '8px' } },
+              h('div', { style: { width: '12px', height: '3px', background: '#64748b', borderRadius: '2px' } }),
+              h('span', { style: { color: '#94a3b8', fontFamily: "'JetBrains Mono', monospace" } },
+                `2024: ${cumulativeData.year2024[hoveredPoint].toLocaleString()}`)
+            ),
+            h('div', { style: { display: 'flex', alignItems: 'center', gap: '8px' } },
+              h('div', { style: { width: '12px', height: '3px', background: 'rgba(148, 163, 184, 0.5)', borderRadius: '2px' } }),
+              h('span', { style: { color: '#64748b', fontFamily: "'JetBrains Mono', monospace" } },
+                `Avg: ${cumulativeData.average[hoveredPoint].toLocaleString()}`)
+            )
+          )
+        )
+      );
+    };
+
     return h('div', { style: styles.container },
       h('style', null, `
         @import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@500&display=swap');
@@ -294,6 +541,15 @@ since 2011, tornado activity moderated significantly in the second half of the y
           from { height: 0; }
         }
         .animated-bar { animation: growUp 0.6s cubic-bezier(0.4, 0, 0.2, 1) forwards; }
+        @keyframes drawLine {
+          from { stroke-dashoffset: 2000; }
+          to { stroke-dashoffset: 0; }
+        }
+        .line-animate {
+          stroke-dasharray: 2000;
+          stroke-dashoffset: 2000;
+          animation: drawLine 2s ease-out forwards;
+        }
         @media (max-width: 768px) {
           #tornado-review-root .stats-grid { grid-template-columns: repeat(2, 1fr) !important; }
         }
@@ -324,6 +580,14 @@ since 2011, tornado activity moderated significantly in the second half of the y
           h('button', {
             style: {
               ...styles.tab,
+              background: activeTab === 'cumulative' ? 'rgba(239, 68, 68, 0.2)' : 'transparent',
+              color: activeTab === 'cumulative' ? '#ef4444' : '#64748b',
+            },
+            onClick: () => setActiveTab('cumulative')
+          }, 'Season Trend'),
+          h('button', {
+            style: {
+              ...styles.tab,
               background: activeTab === 'monthly' ? 'rgba(239, 68, 68, 0.2)' : 'transparent',
               color: activeTab === 'monthly' ? '#ef4444' : '#64748b',
             },
@@ -349,6 +613,32 @@ since 2011, tornado activity moderated significantly in the second half of the y
 
         // Chart Container
         h('div', { style: styles.chartContainer },
+
+          // Cumulative Chart (Season Trend)
+          activeTab === 'cumulative' && h('div', null,
+            h('div', { style: { marginBottom: '16px' } },
+              h('div', { style: { color: '#94a3b8', fontSize: '14px' } },
+                'Cumulative tornado reports throughout the year compared to 2024 and historical average (2000-2023)'
+              )
+            ),
+            renderCumulativeChart(),
+            h('div', { style: styles.legend },
+              h('div', { style: styles.legendItem },
+                h('div', { style: { width: '20px', height: '3px', background: '#ef4444', borderRadius: '2px' } }),
+                h('span', null, '2025 Season')
+              ),
+              h('div', { style: styles.legendItem },
+                h('div', { style: { width: '20px', height: '3px', background: '#64748b', borderRadius: '2px', borderStyle: 'dashed' } }),
+                h('span', null, '2024 Season')
+              ),
+              h('div', { style: styles.legendItem },
+                h('div', { style: { width: '20px', height: '3px', background: 'rgba(148, 163, 184, 0.5)', borderRadius: '2px' } }),
+                h('span', null, 'Historical Average')
+              )
+            )
+          ),
+
+          // Monthly Distribution
           activeTab === 'monthly' && h('div', null,
             h('div', { style: styles.monthlyChart },
               monthlyData.map((month, i) =>
@@ -359,12 +649,12 @@ since 2011, tornado activity moderated significantly in the second half of the y
                   onMouseEnter: () => setHoveredMonth(i),
                   onMouseLeave: () => setHoveredMonth(null),
                 },
+                  hoveredMonth === i && h('div', { style: styles.tooltip },
+                    h('div', { style: { color: '#f8fafc', fontWeight: '600', marginBottom: '4px' } }, month.month + ' 2025'),
+                    h('div', { style: { color: getStatusColor(month.status), fontSize: '18px', fontWeight: '700' } }, month.tornadoes + ' tornadoes'),
+                    h('div', { style: { color: '#64748b', fontSize: '12px', marginTop: '4px' } }, 'Historical avg: ' + month.avg)
+                  ),
                   h('div', { style: styles.barContainer },
-                    hoveredMonth === i && h('div', { style: styles.tooltip },
-                      h('div', { style: { color: '#f8fafc', fontWeight: '600', marginBottom: '4px' } }, month.month + ' 2025'),
-                      h('div', { style: { color: getStatusColor(month.status), fontSize: '18px', fontWeight: '700' } }, month.tornadoes + ' tornadoes'),
-                      h('div', { style: { color: '#64748b', fontSize: '12px', marginTop: '4px' } }, 'Avg: ' + month.avg)
-                    ),
                     h('div', {
                       className: animated ? 'bar animated-bar' : 'bar',
                       style: {

--- a/posts/2026-01-13-2025-tornado-year-in-review/index.qmd
+++ b/posts/2026-01-13-2025-tornado-year-in-review/index.qmd
@@ -1,0 +1,522 @@
+---
+title: "2025 U.S. Tornado Season: Year in Review"
+date: 2026-01-13
+categories: [analysis, severe-weather, insurance, visualization]
+subtitle: "An interactive visualization of the fourth most active tornado season in 15 years"
+draft: false
+freeze: true
+---
+
+The 2025 U.S. tornado season delivered a volatile year marked by record-breaking spring activity, the
+first EF5 tornado since 2013, and significant insured losses—but ultimately finished below 2024's
+near-historic pace. This interactive visualization provides a comprehensive view of the season's
+activity and its implications for the property-casualty insurance industry.
+
+## Season overview
+
+With approximately **1,551 preliminary tornado reports**, 2025 ranks as the fourth most active
+tornado season in the past 15 years. While spring outbreaks put the year on pace to be the worst
+since 2011, tornado activity moderated significantly in the second half of the year.
+
+```{=html}
+<div id="tornado-review-root"></div>
+
+<script src="https://unpkg.com/react@18/umd/react.production.min.js" crossorigin></script>
+<script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js" crossorigin></script>
+
+<script>
+(function() {
+  const { useState, useEffect, createElement: h } = React;
+
+  const monthlyData = [
+    { month: 'Jan', tornadoes: 16, avg: 35, status: 'below' },
+    { month: 'Feb', tornadoes: 39, avg: 29, status: 'average' },
+    { month: 'Mar', tornadoes: 239, avg: 80, status: 'record' },
+    { month: 'Apr', tornadoes: 315, avg: 155, status: 'above' },
+    { month: 'May', tornadoes: 405, avg: 276, status: 'above' },
+    { month: 'Jun', tornadoes: 282, avg: 243, status: 'above' },
+    { month: 'Jul', tornadoes: 95, avg: 94, status: 'average' },
+    { month: 'Aug', tornadoes: 53, avg: 73, status: 'below' },
+    { month: 'Sep', tornadoes: 60, avg: 69, status: 'below' },
+    { month: 'Oct', tornadoes: 26, avg: 56, status: 'below' },
+    { month: 'Nov', tornadoes: 10, avg: 52, status: 'below' },
+    { month: 'Dec', tornadoes: 15, avg: 24, status: 'below' },
+  ];
+
+  const yearlyComparison = [
+    { year: '2011', tornadoes: 1691, deaths: 553, highlight: false },
+    { year: '2024', tornadoes: 1796, deaths: 54, highlight: false },
+    { year: '2025', tornadoes: 1551, deaths: 67, highlight: true },
+    { year: '2022', tornadoes: 1331, deaths: 25, highlight: false },
+    { year: '2023', tornadoes: 1423, deaths: 83, highlight: false },
+    { year: 'Average', tornadoes: 1200, deaths: 78, highlight: false },
+  ];
+
+  const notableEvents = [
+    { date: 'Apr 2-7', event: 'Spring Super Outbreak', tornadoes: 157, description: 'Devastating outbreak with historic floods, 74 tornadoes on April 2 alone' },
+    { date: 'Jun 20', event: 'Enderlin, ND EF5', tornadoes: 1, description: 'First EF5 tornado since 2013, winds exceeding 210 mph' },
+    { date: 'Mar 14-15', event: 'Record March Outbreak', tornadoes: 89, description: 'Contributed to the most active March since records began in 1950' },
+    { date: 'Dec 28', event: 'Late Season Outbreak', tornadoes: 15, description: 'Illinois outbreak including an EF-2 with 120 mph winds' },
+  ];
+
+  const totalTornadoes = monthlyData.reduce((sum, m) => sum + m.tornadoes, 0);
+  const totalAvg = monthlyData.reduce((sum, m) => sum + m.avg, 0);
+  const maxMonth = Math.max(...monthlyData.map(m => m.tornadoes));
+
+  function TornadoReviewApp() {
+    const [hoveredMonth, setHoveredMonth] = useState(null);
+    const [activeTab, setActiveTab] = useState('monthly');
+    const [animated, setAnimated] = useState(false);
+
+    useEffect(() => {
+      const timer = setTimeout(() => setAnimated(true), 100);
+      return () => clearTimeout(timer);
+    }, []);
+
+    const getBarHeight = (value) => (value / maxMonth) * 100;
+
+    const getStatusColor = (status) => {
+      switch(status) {
+        case 'record': return '#dc2626';
+        case 'above': return '#f97316';
+        case 'average': return '#eab308';
+        case 'below': return '#22c55e';
+        default: return '#64748b';
+      }
+    };
+
+    const styles = {
+      container: {
+        background: 'linear-gradient(135deg, #0f172a 0%, #1e293b 50%, #0f172a 100%)',
+        padding: '40px 20px',
+        fontFamily: "'DM Sans', -apple-system, BlinkMacSystemFont, sans-serif",
+        borderRadius: '12px',
+        marginBottom: '24px',
+      },
+      innerContainer: {
+        maxWidth: '1100px',
+        margin: '0 auto',
+      },
+      header: {
+        marginBottom: '32px',
+        textAlign: 'center',
+      },
+      badge: {
+        display: 'inline-block',
+        padding: '6px 16px',
+        background: 'rgba(239, 68, 68, 0.15)',
+        borderRadius: '20px',
+        marginBottom: '16px',
+        border: '1px solid rgba(239, 68, 68, 0.3)',
+      },
+      badgeText: {
+        color: '#ef4444',
+        fontSize: '13px',
+        fontWeight: '600',
+        letterSpacing: '0.5px',
+      },
+      title: {
+        fontSize: '36px',
+        fontWeight: '700',
+        color: '#f8fafc',
+        margin: '0 0 8px 0',
+        letterSpacing: '-0.5px',
+      },
+      subtitle: {
+        fontSize: '16px',
+        color: '#94a3b8',
+        margin: 0,
+      },
+      statsGrid: {
+        display: 'grid',
+        gridTemplateColumns: 'repeat(4, 1fr)',
+        gap: '16px',
+        marginBottom: '32px',
+      },
+      statCard: {
+        background: 'rgba(255,255,255,0.03)',
+        backdropFilter: 'blur(10px)',
+        borderRadius: '16px',
+        padding: '20px',
+        border: '1px solid rgba(255,255,255,0.08)',
+        transition: 'transform 0.2s ease, box-shadow 0.2s ease',
+      },
+      statLabel: {
+        fontSize: '12px',
+        color: '#64748b',
+        fontWeight: '500',
+        marginBottom: '8px',
+        textTransform: 'uppercase',
+        letterSpacing: '0.5px',
+      },
+      statValue: {
+        fontSize: '28px',
+        fontWeight: '700',
+        fontFamily: "'JetBrains Mono', monospace",
+      },
+      statSublabel: {
+        fontSize: '13px',
+        color: '#94a3b8',
+        marginTop: '4px',
+      },
+      tabContainer: {
+        display: 'flex',
+        gap: '8px',
+        marginBottom: '24px',
+        padding: '4px',
+        background: 'rgba(255,255,255,0.03)',
+        borderRadius: '12px',
+        width: 'fit-content',
+      },
+      tab: {
+        padding: '10px 20px',
+        borderRadius: '8px',
+        border: 'none',
+        cursor: 'pointer',
+        fontSize: '14px',
+        fontWeight: '500',
+        transition: 'all 0.2s ease',
+      },
+      chartContainer: {
+        background: 'rgba(255,255,255,0.02)',
+        borderRadius: '20px',
+        border: '1px solid rgba(255,255,255,0.06)',
+        padding: '24px',
+        overflow: 'hidden',
+      },
+      monthlyChart: {
+        display: 'flex',
+        alignItems: 'flex-end',
+        justifyContent: 'space-between',
+        height: '300px',
+        gap: '8px',
+        paddingTop: '40px',
+      },
+      barGroup: {
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: '8px',
+        cursor: 'pointer',
+      },
+      barContainer: {
+        width: '100%',
+        height: '240px',
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'flex-end',
+        alignItems: 'center',
+        position: 'relative',
+      },
+      bar: {
+        width: '80%',
+        borderRadius: '4px 4px 0 0',
+        transition: 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)',
+        position: 'relative',
+      },
+      avgLine: {
+        position: 'absolute',
+        width: '100%',
+        height: '2px',
+        background: 'rgba(148, 163, 184, 0.5)',
+        borderRadius: '1px',
+      },
+      monthLabel: {
+        fontSize: '12px',
+        color: '#94a3b8',
+        fontWeight: '500',
+      },
+      tooltip: {
+        position: 'absolute',
+        bottom: '100%',
+        left: '50%',
+        transform: 'translateX(-50%)',
+        background: 'rgba(15, 23, 42, 0.95)',
+        padding: '12px 16px',
+        borderRadius: '8px',
+        border: '1px solid rgba(255,255,255,0.1)',
+        whiteSpace: 'nowrap',
+        zIndex: 10,
+        marginBottom: '8px',
+      },
+      eventCard: {
+        background: 'rgba(255,255,255,0.02)',
+        borderRadius: '16px',
+        padding: '20px',
+        border: '1px solid rgba(255,255,255,0.06)',
+        marginBottom: '12px',
+        display: 'grid',
+        gridTemplateColumns: '100px 1fr',
+        gap: '16px',
+        alignItems: 'start',
+      },
+      legend: {
+        display: 'flex',
+        gap: '20px',
+        marginTop: '20px',
+        flexWrap: 'wrap',
+        justifyContent: 'center',
+      },
+      legendItem: {
+        display: 'flex',
+        alignItems: 'center',
+        gap: '8px',
+        fontSize: '12px',
+        color: '#94a3b8',
+      },
+      legendDot: {
+        width: '10px',
+        height: '10px',
+        borderRadius: '2px',
+      },
+      footer: {
+        marginTop: '24px',
+        textAlign: 'center',
+        color: '#475569',
+        fontSize: '12px',
+      },
+    };
+
+    const stats = [
+      { label: 'Total Tornadoes', value: '1,551', sublabel: '4th highest in 15 years', color: '#ef4444' },
+      { label: 'Deaths', value: '67', sublabel: 'Below 20-yr avg of 78', color: '#f97316' },
+      { label: 'Vs. Average', value: '+29%', sublabel: '1,200 historical avg', color: '#eab308' },
+      { label: 'EF5 Tornadoes', value: '1', sublabel: 'First since 2013', color: '#dc2626' },
+    ];
+
+    return h('div', { style: styles.container },
+      h('style', null, `
+        @import url('https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=JetBrains+Mono:wght@500&display=swap');
+        .stat-card:hover { transform: translateY(-2px); box-shadow: 0 8px 30px rgba(0,0,0,0.3); }
+        .bar-group:hover .bar { filter: brightness(1.2); }
+        @keyframes growUp {
+          from { height: 0; }
+        }
+        .animated-bar { animation: growUp 0.6s cubic-bezier(0.4, 0, 0.2, 1) forwards; }
+        @media (max-width: 768px) {
+          #tornado-review-root .stats-grid { grid-template-columns: repeat(2, 1fr) !important; }
+        }
+      `),
+      h('div', { style: styles.innerContainer },
+        // Header
+        h('div', { style: styles.header },
+          h('div', { style: styles.badge },
+            h('span', { style: styles.badgeText }, '2025 SEVERE WEATHER REVIEW')
+          ),
+          h('h1', { style: styles.title }, 'U.S. Tornado Activity'),
+          h('p', { style: styles.subtitle }, 'Preliminary tornado reports from NOAA Storm Prediction Center')
+        ),
+
+        // Stats Cards
+        h('div', { style: styles.statsGrid, className: 'stats-grid' },
+          stats.map((stat, i) =>
+            h('div', { key: i, className: 'stat-card', style: styles.statCard },
+              h('div', { style: styles.statLabel }, stat.label),
+              h('div', { style: { ...styles.statValue, color: stat.color } }, stat.value),
+              h('div', { style: styles.statSublabel }, stat.sublabel)
+            )
+          )
+        ),
+
+        // Tabs
+        h('div', { style: styles.tabContainer },
+          h('button', {
+            style: {
+              ...styles.tab,
+              background: activeTab === 'monthly' ? 'rgba(239, 68, 68, 0.2)' : 'transparent',
+              color: activeTab === 'monthly' ? '#ef4444' : '#64748b',
+            },
+            onClick: () => setActiveTab('monthly')
+          }, 'Monthly Distribution'),
+          h('button', {
+            style: {
+              ...styles.tab,
+              background: activeTab === 'events' ? 'rgba(239, 68, 68, 0.2)' : 'transparent',
+              color: activeTab === 'events' ? '#ef4444' : '#64748b',
+            },
+            onClick: () => setActiveTab('events')
+          }, 'Notable Events'),
+          h('button', {
+            style: {
+              ...styles.tab,
+              background: activeTab === 'compare' ? 'rgba(239, 68, 68, 0.2)' : 'transparent',
+              color: activeTab === 'compare' ? '#ef4444' : '#64748b',
+            },
+            onClick: () => setActiveTab('compare')
+          }, 'Year Comparison')
+        ),
+
+        // Chart Container
+        h('div', { style: styles.chartContainer },
+          activeTab === 'monthly' && h('div', null,
+            h('div', { style: styles.monthlyChart },
+              monthlyData.map((month, i) =>
+                h('div', {
+                  key: month.month,
+                  className: 'bar-group',
+                  style: styles.barGroup,
+                  onMouseEnter: () => setHoveredMonth(i),
+                  onMouseLeave: () => setHoveredMonth(null),
+                },
+                  h('div', { style: styles.barContainer },
+                    hoveredMonth === i && h('div', { style: styles.tooltip },
+                      h('div', { style: { color: '#f8fafc', fontWeight: '600', marginBottom: '4px' } }, month.month + ' 2025'),
+                      h('div', { style: { color: getStatusColor(month.status), fontSize: '18px', fontWeight: '700' } }, month.tornadoes + ' tornadoes'),
+                      h('div', { style: { color: '#64748b', fontSize: '12px', marginTop: '4px' } }, 'Avg: ' + month.avg)
+                    ),
+                    h('div', {
+                      className: animated ? 'bar animated-bar' : 'bar',
+                      style: {
+                        ...styles.bar,
+                        height: animated ? getBarHeight(month.tornadoes) + '%' : '0%',
+                        background: `linear-gradient(180deg, ${getStatusColor(month.status)} 0%, ${getStatusColor(month.status)}88 100%)`,
+                        animationDelay: (i * 50) + 'ms',
+                        boxShadow: hoveredMonth === i ? `0 0 20px ${getStatusColor(month.status)}40` : 'none',
+                      }
+                    }),
+                    h('div', {
+                      style: {
+                        ...styles.avgLine,
+                        bottom: getBarHeight(month.avg) + '%',
+                      }
+                    })
+                  ),
+                  h('div', { style: styles.monthLabel }, month.month)
+                )
+              )
+            ),
+            h('div', { style: styles.legend },
+              h('div', { style: styles.legendItem },
+                h('div', { style: { ...styles.legendDot, background: '#dc2626' } }),
+                h('span', null, 'Record')
+              ),
+              h('div', { style: styles.legendItem },
+                h('div', { style: { ...styles.legendDot, background: '#f97316' } }),
+                h('span', null, 'Above Average')
+              ),
+              h('div', { style: styles.legendItem },
+                h('div', { style: { ...styles.legendDot, background: '#eab308' } }),
+                h('span', null, 'Average')
+              ),
+              h('div', { style: styles.legendItem },
+                h('div', { style: { ...styles.legendDot, background: '#22c55e' } }),
+                h('span', null, 'Below Average')
+              ),
+              h('div', { style: styles.legendItem },
+                h('div', { style: { ...styles.legendDot, background: 'transparent', border: '2px solid rgba(148, 163, 184, 0.5)' } }),
+                h('span', null, 'Historical Average')
+              )
+            )
+          ),
+
+          activeTab === 'events' && h('div', null,
+            notableEvents.map((event, i) =>
+              h('div', { key: i, style: styles.eventCard },
+                h('div', null,
+                  h('div', { style: { color: '#ef4444', fontSize: '14px', fontWeight: '600' } }, event.date),
+                  h('div', { style: { color: '#64748b', fontSize: '12px', marginTop: '4px' } }, event.tornadoes + ' tornado' + (event.tornadoes > 1 ? 'es' : ''))
+                ),
+                h('div', null,
+                  h('div', { style: { color: '#f8fafc', fontSize: '16px', fontWeight: '600', marginBottom: '8px' } }, event.event),
+                  h('div', { style: { color: '#94a3b8', fontSize: '14px', lineHeight: '1.5' } }, event.description)
+                )
+              )
+            )
+          ),
+
+          activeTab === 'compare' && h('div', null,
+            h('div', { style: { display: 'grid', gap: '8px' } },
+              yearlyComparison.map((year, i) =>
+                h('div', {
+                  key: i,
+                  style: {
+                    display: 'grid',
+                    gridTemplateColumns: '80px 1fr 100px 80px',
+                    alignItems: 'center',
+                    padding: '16px 20px',
+                    background: year.highlight ? 'rgba(239, 68, 68, 0.1)' : 'rgba(255,255,255,0.02)',
+                    borderRadius: '12px',
+                    border: year.highlight ? '1px solid rgba(239, 68, 68, 0.3)' : '1px solid rgba(255,255,255,0.04)',
+                  }
+                },
+                  h('div', { style: { color: year.highlight ? '#ef4444' : '#f8fafc', fontWeight: '600' } }, year.year),
+                  h('div', { style: { paddingRight: '20px' } },
+                    h('div', {
+                      style: {
+                        height: '8px',
+                        background: year.highlight
+                          ? 'linear-gradient(90deg, #ef4444 0%, #dc2626 100%)'
+                          : 'linear-gradient(90deg, #64748b 0%, #475569 100%)',
+                        borderRadius: '4px',
+                        width: (year.tornadoes / 1800 * 100) + '%',
+                      }
+                    })
+                  ),
+                  h('div', { style: { color: year.highlight ? '#ef4444' : '#94a3b8', fontFamily: "'JetBrains Mono', monospace", fontWeight: '500' } }, year.tornadoes.toLocaleString()),
+                  h('div', { style: { color: '#64748b', fontSize: '12px' } }, year.deaths + ' deaths')
+                )
+              )
+            )
+          )
+        ),
+
+        // Footer
+        h('div', { style: styles.footer },
+          'Data reflects preliminary tornado reports from NOAA Storm Prediction Center. Final counts may vary after verification.'
+        )
+      )
+    );
+  }
+
+  const root = ReactDOM.createRoot(document.getElementById('tornado-review-root'));
+  root.render(h(TornadoReviewApp));
+})();
+</script>
+```
+
+## Key takeaways for insurers
+
+**Record spring activity**: March 2025 broke records with 239 confirmed tornadoes, the most active
+March since records began in 1950. The April 2-7 super outbreak produced 157 tornadoes and
+contributed to multiple billion-dollar insured loss events.
+
+**First EF5 since 2013**: The Enderlin, North Dakota tornado on June 20 was officially rated EF5
+with winds exceeding 210 mph—the first tornado of this intensity in over a decade. This serves as a
+reminder that catastrophic wind events remain a tail risk for property portfolios.
+
+**Favorable second half**: Despite the explosive spring, tornado activity moderated significantly
+from July onward. August through December all finished below historical averages, with November
+recording only 10 tornadoes—the lowest for that month since 2012.
+
+**State concentration**: Texas led with 145 preliminary reports, followed closely by Illinois at 141
+(the second-highest count nationally). Missouri and Mississippi rounded out the top four, reinforcing
+the continued importance of geographic diversification for property insurers.
+
+**Below-average fatalities**: Despite elevated tornado counts, the 67 confirmed deaths remained below
+the 20-year average of 78 fatalities. Improved warning systems and building standards continue to
+reduce casualty rates even as tornado frequency rises.
+
+## Insurance implications
+
+The 2025 season contributed to another year of elevated severe convective storm (SCS) losses, with at
+least eight separate billion-dollar events by mid-year. For property-casualty insurers, the key
+lessons include:
+
+1. **Spring concentration risk** — Over 60% of 2025's tornado activity occurred in the March-May
+   window, reinforcing the importance of seasonal exposure management.
+
+2. **EF5 reminder** — While rare, the Enderlin tornado demonstrates that maximum credible loss
+   scenarios must account for violent tornado potential.
+
+3. **Geographic shifts** — Illinois's emergence as the second-most impacted state highlights the
+   expanding "Dixie Alley" phenomenon and the need for dynamic cat modeling.
+
+For a real-time view of current tornado activity and historical benchmarks, explore our
+[Severe Weather Tracker](/tools/severe-weather-tracker/) tool.
+
+## Data sources
+
+Tornado counts are preliminary and sourced from the [NOAA Storm Prediction Center](https://www.spc.noaa.gov/wcm/).
+Final confirmed totals are typically published by the National Centers for Environmental Information
+12-18 months after the season ends.


### PR DESCRIPTION
Interactive visualization of the 2025 tornado season featuring:
- Monthly distribution chart with historical averages
- Notable events including the first EF5 since 2013
- Year-over-year comparison with 2011-2024
- Key statistics: 1,551 tornadoes, 67 deaths, +29% vs average

The post analyzes the fourth most active tornado season in 15 years and its implications for P&C insurance, including spring concentration risk, geographic shifts, and severe convective storm loss trends.